### PR TITLE
Feat : 이메일 인증 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,5 @@ $RECYCLE.BIN/
 *.env
 src/main/generated/
 logs/
+
+src/main/resources/secrets**

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,13 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
+
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5' // or 'jjwt-gson' if you prefer Gson
+
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -28,9 +28,6 @@ dependencies {
 
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 
-	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
-	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
-	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5' // or 'jjwt-gson' if you prefer Gson
 
 }
 

--- a/src/main/java/org/chunsik/pq/config/WebConfig.java
+++ b/src/main/java/org/chunsik/pq/config/WebConfig.java
@@ -13,7 +13,7 @@ public class WebConfig implements WebMvcConfigurer {
             .allowedOrigins("http://localhost:3000", "43.203.217.119")
             .allowedOriginPatterns("*")
             .allowedHeaders("*")
-            .allowCredentials(false)
+            .allowCredentials(true)
             .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH");
     }
 }

--- a/src/main/java/org/chunsik/pq/config/WebConfig.java
+++ b/src/main/java/org/chunsik/pq/config/WebConfig.java
@@ -1,0 +1,19 @@
+package org.chunsik.pq.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+            .allowedOrigins("http://localhost:3000", "43.203.217.119")
+            .allowedOriginPatterns("*")
+            .allowedHeaders("*")
+            .allowCredentials(false)
+            .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH");
+    }
+}

--- a/src/main/java/org/chunsik/pq/email/controller/EmailController.java
+++ b/src/main/java/org/chunsik/pq/email/controller/EmailController.java
@@ -20,34 +20,35 @@ public class EmailController {
     // 인증번호 요청
     @PostMapping("/request")
     public ResponseEntity<String> sendEmail(@RequestParam String email, HttpServletRequest request, HttpServletResponse response) {
-        try {
-            if (email == null || email.isEmpty()) {
-                return new ResponseEntity<>("Invalid request format.", HttpStatus.BAD_REQUEST);
-            }
-            emailService.sendSimpleEmail(email, request, response);
-            return new ResponseEntity<>("Verification email sent.", HttpStatus.CREATED);
-        } catch (RuntimeException e) {
-            return new ResponseEntity<>(e.getMessage(), HttpStatus.TOO_MANY_REQUESTS);
-        } catch (Exception e) {
-            return new ResponseEntity<>("Internal server error.", HttpStatus.INTERNAL_SERVER_ERROR);
+        if (email.isEmpty()) {
+            return new ResponseEntity<>("Invalid request format.", HttpStatus.BAD_REQUEST);
         }
+        emailService.sendSimpleEmail(email, request, response);
+        return new ResponseEntity<>("Verification email sent.", HttpStatus.CREATED);
     }
 
     // 인증번호 검증
     @PatchMapping("/verification")
     public ResponseEntity<String> verifyEmail(@RequestParam String email, @RequestParam String code) {
-        try {
-            if (email == null || email.isEmpty() || code == null || code.isEmpty()) {
-                return new ResponseEntity<>("Invalid request format.", HttpStatus.BAD_REQUEST);
-            }
-            boolean isVerified = emailService.verifyCode(email, code);
-            if (isVerified) {
-                return new ResponseEntity<>("Secret code verified successfully. Confirmation status updated.", HttpStatus.OK);
-            } else {
-                return new ResponseEntity<>("Invalid or expired secret code.", HttpStatus.UNAUTHORIZED);
-            }
-        } catch (Exception e) {
-            return new ResponseEntity<>("Internal server error.", HttpStatus.INTERNAL_SERVER_ERROR);
+        if (email.isEmpty() || code.isEmpty()) {
+            return new ResponseEntity<>("Invalid request format.", HttpStatus.BAD_REQUEST);
         }
+        boolean isVerified = emailService.verifyCode(email, code);
+        if (isVerified) {
+            return new ResponseEntity<>("Secret code verified successfully. Confirmation status updated.", HttpStatus.OK);
+        } else {
+            return new ResponseEntity<>("Invalid or expired secret code.", HttpStatus.UNAUTHORIZED);
+        }
+    }
+
+    // 예외 처리
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<String> handleRuntimeException(RuntimeException e) {
+        return new ResponseEntity<>(e.getMessage(), HttpStatus.TOO_MANY_REQUESTS);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<String> handleException(Exception e) {
+        return new ResponseEntity<>("Internal server error.", HttpStatus.INTERNAL_SERVER_ERROR);
     }
 }

--- a/src/main/java/org/chunsik/pq/email/controller/EmailController.java
+++ b/src/main/java/org/chunsik/pq/email/controller/EmailController.java
@@ -1,5 +1,7 @@
 package org.chunsik.pq.email.controller;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.chunsik.pq.email.service.EmailService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -7,19 +9,23 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/users")
+@RequestMapping("/users/email")
 public class EmailController {
 
     @Autowired
     private EmailService emailService;
 
-    @PostMapping("/email/request")
-    public ResponseEntity<String> sendEmail(@RequestParam String toEmail) {
-        emailService.sendSimpleEmail(toEmail);
-        return new ResponseEntity<>("Verification email sent.", HttpStatus.CREATED);
+    @PostMapping("/request")
+    public ResponseEntity<String> sendEmail(@RequestParam String toEmail, HttpServletRequest request, HttpServletResponse response) {
+        try {
+            emailService.sendSimpleEmail(toEmail, request, response);
+            return new ResponseEntity<>("Verification email sent.", HttpStatus.CREATED);
+        } catch (RuntimeException e) {
+            return new ResponseEntity<>(e.getMessage(), HttpStatus.TOO_MANY_REQUESTS);
+        }
     }
 
-    @PatchMapping("/email/verification")
+    @PatchMapping("/verification")
     public ResponseEntity<String> verifyEmail(@RequestParam String email, @RequestParam String code) {
         boolean isVerified = emailService.verifyCode(email, code);
         if (isVerified) {

--- a/src/main/java/org/chunsik/pq/email/controller/EmailController.java
+++ b/src/main/java/org/chunsik/pq/email/controller/EmailController.java
@@ -1,0 +1,31 @@
+package org.chunsik.pq.email.controller;
+
+import org.chunsik.pq.email.service.EmailService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/users")
+public class EmailController {
+
+    @Autowired
+    private EmailService emailService;
+
+    @PostMapping("/email/request")
+    public ResponseEntity<String> sendEmail(@RequestParam String toEmail) {
+        emailService.sendSimpleEmail(toEmail);
+        return new ResponseEntity<>("Verification email sent.", HttpStatus.CREATED);
+    }
+
+    @PatchMapping("/email/verification")
+    public ResponseEntity<String> verifyEmail(@RequestParam String email, @RequestParam String code) {
+        boolean isVerified = emailService.verifyCode(email, code);
+        if (isVerified) {
+            return new ResponseEntity<>("Secret code verified successfully. Confirmation status updated.", HttpStatus.OK);
+        } else {
+            return new ResponseEntity<>("Invalid or expired secret code.", HttpStatus.UNAUTHORIZED);
+        }
+    }
+}

--- a/src/main/java/org/chunsik/pq/email/controller/EmailController.java
+++ b/src/main/java/org/chunsik/pq/email/controller/EmailController.java
@@ -5,6 +5,7 @@ import jakarta.servlet.http.HttpServletResponse;
 
 import lombok.RequiredArgsConstructor;
 
+import org.chunsik.pq.email.exception.TooManyRequestsException;
 import org.chunsik.pq.email.service.EmailService;
 
 import org.springframework.http.HttpStatus;
@@ -42,9 +43,14 @@ public class EmailController {
     }
 
     // 예외 처리
+    @ExceptionHandler(TooManyRequestsException.class)
+    public ResponseEntity<String> handleTooManyRequestsException(TooManyRequestsException e) {
+        return new ResponseEntity<>(e.getMessage(), HttpStatus.TOO_MANY_REQUESTS);
+    }
+
     @ExceptionHandler(RuntimeException.class)
     public ResponseEntity<String> handleRuntimeException(RuntimeException e) {
-        return new ResponseEntity<>(e.getMessage(), HttpStatus.TOO_MANY_REQUESTS);
+        return new ResponseEntity<>("Internal server error.", HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/org/chunsik/pq/email/controller/EmailController.java
+++ b/src/main/java/org/chunsik/pq/email/controller/EmailController.java
@@ -2,36 +2,52 @@ package org.chunsik.pq.email.controller;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+
+import lombok.RequiredArgsConstructor;
+
 import org.chunsik.pq.email.service.EmailService;
-import org.springframework.beans.factory.annotation.Autowired;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/users/email")
+@RequiredArgsConstructor
 public class EmailController {
+    private final EmailService emailService;
 
-    @Autowired
-    private EmailService emailService;
-
+    // 인증번호 요청
     @PostMapping("/request")
-    public ResponseEntity<String> sendEmail(@RequestParam String toEmail, HttpServletRequest request, HttpServletResponse response) {
+    public ResponseEntity<String> sendEmail(@RequestParam String email, HttpServletRequest request, HttpServletResponse response) {
         try {
-            emailService.sendSimpleEmail(toEmail, request, response);
+            if (email == null || email.isEmpty()) {
+                return new ResponseEntity<>("Invalid request format.", HttpStatus.BAD_REQUEST);
+            }
+            emailService.sendSimpleEmail(email, request, response);
             return new ResponseEntity<>("Verification email sent.", HttpStatus.CREATED);
         } catch (RuntimeException e) {
             return new ResponseEntity<>(e.getMessage(), HttpStatus.TOO_MANY_REQUESTS);
+        } catch (Exception e) {
+            return new ResponseEntity<>("Internal server error.", HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 
+    // 인증번호 검증
     @PatchMapping("/verification")
     public ResponseEntity<String> verifyEmail(@RequestParam String email, @RequestParam String code) {
-        boolean isVerified = emailService.verifyCode(email, code);
-        if (isVerified) {
-            return new ResponseEntity<>("Secret code verified successfully. Confirmation status updated.", HttpStatus.OK);
-        } else {
-            return new ResponseEntity<>("Invalid or expired secret code.", HttpStatus.UNAUTHORIZED);
+        try {
+            if (email == null || email.isEmpty() || code == null || code.isEmpty()) {
+                return new ResponseEntity<>("Invalid request format.", HttpStatus.BAD_REQUEST);
+            }
+            boolean isVerified = emailService.verifyCode(email, code);
+            if (isVerified) {
+                return new ResponseEntity<>("Secret code verified successfully. Confirmation status updated.", HttpStatus.OK);
+            } else {
+                return new ResponseEntity<>("Invalid or expired secret code.", HttpStatus.UNAUTHORIZED);
+            }
+        } catch (Exception e) {
+            return new ResponseEntity<>("Internal server error.", HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 }

--- a/src/main/java/org/chunsik/pq/email/exception/TooManyRequestsException.java
+++ b/src/main/java/org/chunsik/pq/email/exception/TooManyRequestsException.java
@@ -1,0 +1,7 @@
+package org.chunsik.pq.email.exception;
+
+public class TooManyRequestsException extends RuntimeException {
+    public TooManyRequestsException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/chunsik/pq/email/model/EmailConfirm.java
+++ b/src/main/java/org/chunsik/pq/email/model/EmailConfirm.java
@@ -1,8 +1,8 @@
 package org.chunsik.pq.email.model;
 
 import jakarta.persistence.Entity;
-
 import jakarta.persistence.*;
+
 import lombok.Getter;
 import lombok.Setter;
 

--- a/src/main/java/org/chunsik/pq/email/model/EmailConfirm.java
+++ b/src/main/java/org/chunsik/pq/email/model/EmailConfirm.java
@@ -1,39 +1,31 @@
 package org.chunsik.pq.email.model;
 
-import jakarta.persistence.Entity;
 import jakarta.persistence.*;
-
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
 @Getter
-@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(toBuilder = true)
+@Table(name="email_confirm")
 @Entity
-@Table(name = "email_confirm")
 public class EmailConfirm {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Integer id;
+    private Long id;
 
-    @Column(nullable = false)
     private String email;
-
-    @Column(nullable = false)
     private String secretCode;
-
-    @Column(nullable = false)
     private LocalDateTime createdAt;
-
-    @Column(nullable = false)
+    @Builder.Default
     private Boolean isSend = false;
-
     private LocalDateTime sendedAt;
-
-    @Column(nullable = false)
+    @Builder.Default
     private Boolean confirmation = false;
-
     private LocalDateTime confirmedAt;
-
 }

--- a/src/main/java/org/chunsik/pq/email/model/EmailConfirm.java
+++ b/src/main/java/org/chunsik/pq/email/model/EmailConfirm.java
@@ -1,0 +1,39 @@
+package org.chunsik.pq.email.model;
+
+import jakarta.persistence.Entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "email_confirm")
+public class EmailConfirm {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @Column(nullable = false)
+    private String email;
+
+    @Column(nullable = false)
+    private String secretCode;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false)
+    private Boolean isSend = false;
+
+    private LocalDateTime sendedAt;
+
+    @Column(nullable = false)
+    private Boolean confirmation = false;
+
+    private LocalDateTime confirmedAt;
+
+}

--- a/src/main/java/org/chunsik/pq/email/repository/EmailConfirmRepository.java
+++ b/src/main/java/org/chunsik/pq/email/repository/EmailConfirmRepository.java
@@ -1,0 +1,11 @@
+package org.chunsik.pq.email.repository;
+
+import org.chunsik.pq.email.model.EmailConfirm;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
+
+public interface EmailConfirmRepository extends JpaRepository<EmailConfirm, Integer> {
+    Optional<EmailConfirm> findByEmailAndSecretCode(String email, String secretCode);
+
+    Optional<EmailConfirm> findByEmail(String email);
+}

--- a/src/main/java/org/chunsik/pq/email/repository/EmailConfirmRepository.java
+++ b/src/main/java/org/chunsik/pq/email/repository/EmailConfirmRepository.java
@@ -5,7 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface EmailConfirmRepository extends JpaRepository<EmailConfirm, Integer> {
-    Optional<EmailConfirm> findByEmailAndSecretCode(String email, String secretCode);
-
     Optional<EmailConfirm> findByEmail(String email);
 }

--- a/src/main/java/org/chunsik/pq/email/service/EmailService.java
+++ b/src/main/java/org/chunsik/pq/email/service/EmailService.java
@@ -1,0 +1,89 @@
+package org.chunsik.pq.email.service;
+
+import org.chunsik.pq.email.model.EmailConfirm;
+import org.chunsik.pq.email.repository.EmailConfirmRepository;
+import org.chunsik.pq.email.util.AESUtil;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.Random;
+
+@Service
+public class EmailService {
+
+    @Autowired
+    private JavaMailSender mailSender;
+
+    @Autowired
+    private EmailConfirmRepository emailConfirmRepository;
+
+    public void sendSimpleEmail(String toEmail) {
+        // 6자리 난수 생성
+        String verificationCode = generateVerificationCode();
+
+        // secret_code 암호화
+        String encryptedCode = null;
+        try {
+            encryptedCode = AESUtil.encrypt(verificationCode);
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RuntimeException("Error while encrypting the secret code");
+        }
+
+        // 이메일 인증 정보 데이터베이스에 저장
+        EmailConfirm emailConfirm = new EmailConfirm();
+        emailConfirm.setEmail(toEmail);
+        emailConfirm.setSecretCode(encryptedCode);
+        emailConfirm.setCreatedAt(LocalDateTime.now());
+        emailConfirm.setIsSend(true);
+        emailConfirm.setSendedAt(LocalDateTime.now());
+
+        emailConfirmRepository.save(emailConfirm);
+
+        // 이메일 제목과 내용 설정
+        String subject = "이메일 인증번호입니다.";
+        String body = "귀하의 이메일 인증번호는 다음과 같습니다: " + verificationCode;
+
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(toEmail);
+        message.setSubject(subject);
+        message.setText(body);
+        message.setFrom("4Q <no-reply@4q.com>");
+
+        // 이메일 전송
+        mailSender.send(message);
+    }
+
+    private String generateVerificationCode() {
+        Random random = new Random();
+        int code = 100000 + random.nextInt(900000); // 6자리 난수 생성
+        return String.valueOf(code);
+    }
+
+    public boolean verifyCode(String email, String code) {
+        // 이메일과 암호화된 코드로 데이터베이스에서 검색
+        Optional<EmailConfirm> emailConfirmOpt = emailConfirmRepository.findByEmail(email);
+
+        if (emailConfirmOpt.isPresent()) {
+            EmailConfirm emailConfirm = emailConfirmOpt.get();
+            try {
+                String decryptedCode = AESUtil.decrypt(emailConfirm.getSecretCode());
+                if (decryptedCode.equals(code)) {
+                    emailConfirm.setConfirmation(true);
+                    emailConfirm.setConfirmedAt(LocalDateTime.now());
+                    emailConfirmRepository.save(emailConfirm);
+                    return true;
+                }
+            } catch (Exception e) {
+                e.printStackTrace();
+                throw new RuntimeException("Error while decrypting the secret code");
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/main/java/org/chunsik/pq/email/service/EmailService.java
+++ b/src/main/java/org/chunsik/pq/email/service/EmailService.java
@@ -1,6 +1,7 @@
 package org.chunsik.pq.email.service;
 
 import lombok.RequiredArgsConstructor;
+import org.chunsik.pq.email.exception.TooManyRequestsException;
 import org.springframework.beans.factory.annotation.Value;
 import org.chunsik.pq.email.model.EmailConfirm;
 import org.chunsik.pq.email.repository.EmailConfirmRepository;
@@ -29,7 +30,7 @@ public class EmailService {
 
     private static final int MAX_REQUESTS = 5;
     private static final int COOKIE_EXPIRATION_MINUTES = 30;
-    private static final String REQUEST_COUNT_COOKE_NAME = "requestCount";
+    private static final String REQUEST_COUNT_COOKIE_NAME = "requestCount";
 
     private final RandomGenerator randomGenerator = RandomGeneratorFactory.of("Random").create();
     private final JavaMailSender mailSender;
@@ -37,15 +38,15 @@ public class EmailService {
 
     public void sendSimpleEmail(String email, HttpServletRequest request, HttpServletResponse response) {
         // 쿠키 기반 재전송 제한 체크
-        Optional<Cookie> requestCountCookieOpt = getCookie(request, REQUEST_COUNT_COOKE_NAME);
+        Optional<Cookie> requestCountCookieOpt = getCookie(request, REQUEST_COUNT_COOKIE_NAME);
 
         int requestCount = 1;
 
         if (requestCountCookieOpt.isPresent()) {
             requestCount = Integer.parseInt(requestCountCookieOpt.get().getValue());
 
-            if (requestCount > MAX_REQUESTS) {
-                throw new RuntimeException("Too many requests.");
+            if (requestCount >= MAX_REQUESTS) {
+                throw new TooManyRequestsException("Too many requests.");
             } else {
                 requestCount++;
             }

--- a/src/main/java/org/chunsik/pq/email/service/EmailService.java
+++ b/src/main/java/org/chunsik/pq/email/service/EmailService.java
@@ -4,7 +4,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.chunsik.pq.email.model.EmailConfirm;
 import org.chunsik.pq.email.repository.EmailConfirmRepository;
 import org.chunsik.pq.email.util.AESUtil;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
@@ -12,10 +11,9 @@ import org.springframework.stereotype.Service;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+
 import java.time.Duration;
-import java.time.Instant;
 import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.random.RandomGenerator;
@@ -30,49 +28,39 @@ public class EmailService {
     private static final int MAX_REQUESTS = 5;
     private static final int COOKIE_EXPIRATION_MINUTES = 30;
 
-    private final RandomGenerator randomGenerator = RandomGeneratorFactory.of("Random").create();
+    private final RandomGenerator randomGenerator;
+    private final JavaMailSender mailSender;
+    private final EmailConfirmRepository emailConfirmRepository;
 
-    @Autowired
-    private JavaMailSender mailSender;
+    public EmailService(JavaMailSender mailSender, EmailConfirmRepository emailConfirmRepository) {
+        this.mailSender = mailSender;
+        this.emailConfirmRepository = emailConfirmRepository;
+        this.randomGenerator = RandomGeneratorFactory.of("Random").create();
+    }
 
-    @Autowired
-    private EmailConfirmRepository emailConfirmRepository;
-
-    public void sendSimpleEmail(String toEmail, HttpServletRequest request, HttpServletResponse response) {
+    public void sendSimpleEmail(String email, HttpServletRequest request, HttpServletResponse response) {
         // 쿠키 기반 재전송 제한 체크
-        Optional<Cookie> requestCountCookie = getCookie(request, "requestCount");
-        Optional<Cookie> lastRequestTimeCookie = getCookie(request, "lastRequestTime");
+        Optional<Cookie> requestCountCookieOpt = getCookie(request, "requestCount");
 
         int requestCount = 1;
-        long currentTime = Instant.now().toEpochMilli();
-        long lastRequestTime = currentTime;
 
-        if (requestCountCookie.isPresent() && lastRequestTimeCookie.isPresent()) {
-            requestCount = Integer.parseInt(requestCountCookie.get().getValue());
-            lastRequestTime = Long.parseLong(lastRequestTimeCookie.get().getValue());
+        if (requestCountCookieOpt.isPresent()) {
+            requestCount = Integer.parseInt(requestCountCookieOpt.get().getValue());
 
-            // 시간 제한 확인
-            if (Instant.now().isBefore(Instant.ofEpochMilli(lastRequestTime).plus(COOKIE_EXPIRATION_MINUTES, ChronoUnit.MINUTES))) {
-                if (requestCount >= MAX_REQUESTS) {
-                    throw new RuntimeException("30분 동안 최대 5번의 이메일 인증 요청만 허용됩니다. 나중에 다시 시도해주세요.");
-                } else {
-                    requestCount++;
-                }
+            if (requestCount > MAX_REQUESTS) {
+                throw new RuntimeException("Too many requests.");
             } else {
-                requestCount = 1;
-                lastRequestTime = currentTime;
+                requestCount++;
             }
         }
 
-        // 쿠키 설정
         setCookie(response, "requestCount", String.valueOf(requestCount), COOKIE_EXPIRATION_MINUTES * 60);
-        setCookie(response, "lastRequestTime", String.valueOf(lastRequestTime), COOKIE_EXPIRATION_MINUTES * 60);
 
         // 6자리 난수 생성
         String verificationCode = generateVerificationCode();
 
         // secret_code 암호화
-        String encryptedCode = null;
+        String encryptedCode;
         try {
             encryptedCode = AESUtil.encrypt(verificationCode);
         } catch (Exception e) {
@@ -80,13 +68,25 @@ public class EmailService {
             throw new RuntimeException("Error while encrypting the secret code");
         }
 
-        // 이메일 인증 정보 데이터베이스에 저장
-        EmailConfirm emailConfirm = new EmailConfirm();
-        emailConfirm.setEmail(toEmail);
-        emailConfirm.setSecretCode(encryptedCode);
-        emailConfirm.setCreatedAt(LocalDateTime.now());
-        emailConfirm.setIsSend(true);
-        emailConfirm.setSendedAt(LocalDateTime.now());
+        // 이메일 인증 정보 데이터베이스에 저장 또는 업데이트
+        // 동일 이메일에 대한 여러 데이터가 있으면 에러가 나서
+        // 동일 이메일에 대한 데이터가 있으면 추가하지 않고 기존의 데이터를 업데이트 하는 방식으로 구현
+        Optional<EmailConfirm> existingEmailConfirmOpt = emailConfirmRepository.findByEmail(email);
+        EmailConfirm emailConfirm;
+        if (existingEmailConfirmOpt.isPresent()) {
+            emailConfirm = existingEmailConfirmOpt.get();
+            emailConfirm.setSecretCode(encryptedCode);
+            emailConfirm.setCreatedAt(LocalDateTime.now());
+            emailConfirm.setIsSend(true);
+            emailConfirm.setSendedAt(LocalDateTime.now());
+        } else {
+            emailConfirm = new EmailConfirm();
+            emailConfirm.setEmail(email);
+            emailConfirm.setSecretCode(encryptedCode);
+            emailConfirm.setCreatedAt(LocalDateTime.now());
+            emailConfirm.setIsSend(true);
+            emailConfirm.setSendedAt(LocalDateTime.now());
+        }
 
         emailConfirmRepository.save(emailConfirm);
 
@@ -95,22 +95,20 @@ public class EmailService {
         String body = "귀하의 이메일 인증번호는 다음과 같습니다: " + verificationCode;
 
         SimpleMailMessage message = new SimpleMailMessage();
-        message.setTo(toEmail);
+        message.setTo(email);
         message.setSubject(subject);
         message.setText(body);
         message.setFrom("4Q <no-reply@qqqq.world>");
 
-        // 이메일 전송
         mailSender.send(message);
     }
 
     private String generateVerificationCode() {
-        int code = randomGenerator.nextInt(900000) + 100000; // 6자리 난수 생성
+        int code = randomGenerator.nextInt(900000) + 100000; // 100000~999999 난수 생성
         return String.valueOf(code);
     }
 
     public boolean verifyCode(String email, String code) {
-        // 이메일과 암호화된 코드로 데이터베이스에서 검색
         Optional<EmailConfirm> emailConfirmOpt = emailConfirmRepository.findByEmail(email);
 
         if (emailConfirmOpt.isPresent()) {
@@ -120,7 +118,7 @@ public class EmailService {
 
             // 유효기간 확인
             if (Duration.between(createdAt, now).toMillis() > authCodeExpirationMillis) {
-                return false; // 유효기간 만료
+                return false;
             }
 
             try {

--- a/src/main/java/org/chunsik/pq/email/service/EmailService.java
+++ b/src/main/java/org/chunsik/pq/email/service/EmailService.java
@@ -9,8 +9,14 @@ import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
 
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.time.Duration;
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
 import java.util.Optional;
 import java.util.random.RandomGenerator;
 import java.util.random.RandomGeneratorFactory;
@@ -21,6 +27,9 @@ public class EmailService {
     @Value("${auth-code-expiration-millis}")
     private long authCodeExpirationMillis;
 
+    private static final int MAX_REQUESTS = 5;
+    private static final int COOKIE_EXPIRATION_MINUTES = 30;
+
     private final RandomGenerator randomGenerator = RandomGeneratorFactory.of("Random").create();
 
     @Autowired
@@ -29,7 +38,36 @@ public class EmailService {
     @Autowired
     private EmailConfirmRepository emailConfirmRepository;
 
-    public void sendSimpleEmail(String toEmail) {
+    public void sendSimpleEmail(String toEmail, HttpServletRequest request, HttpServletResponse response) {
+        // 쿠키 기반 재전송 제한 체크
+        Optional<Cookie> requestCountCookie = getCookie(request, "requestCount");
+        Optional<Cookie> lastRequestTimeCookie = getCookie(request, "lastRequestTime");
+
+        int requestCount = 1;
+        long currentTime = Instant.now().toEpochMilli();
+        long lastRequestTime = currentTime;
+
+        if (requestCountCookie.isPresent() && lastRequestTimeCookie.isPresent()) {
+            requestCount = Integer.parseInt(requestCountCookie.get().getValue());
+            lastRequestTime = Long.parseLong(lastRequestTimeCookie.get().getValue());
+
+            // 시간 제한 확인
+            if (Instant.now().isBefore(Instant.ofEpochMilli(lastRequestTime).plus(COOKIE_EXPIRATION_MINUTES, ChronoUnit.MINUTES))) {
+                if (requestCount >= MAX_REQUESTS) {
+                    throw new RuntimeException("30분 동안 최대 5번의 이메일 인증 요청만 허용됩니다. 나중에 다시 시도해주세요.");
+                } else {
+                    requestCount++;
+                }
+            } else {
+                requestCount = 1;
+                lastRequestTime = currentTime;
+            }
+        }
+
+        // 쿠키 설정
+        setCookie(response, "requestCount", String.valueOf(requestCount), COOKIE_EXPIRATION_MINUTES * 60);
+        setCookie(response, "lastRequestTime", String.valueOf(lastRequestTime), COOKIE_EXPIRATION_MINUTES * 60);
+
         // 6자리 난수 생성
         String verificationCode = generateVerificationCode();
 
@@ -60,7 +98,7 @@ public class EmailService {
         message.setTo(toEmail);
         message.setSubject(subject);
         message.setText(body);
-        message.setFrom("4Q <no-reply@4q.com>");
+        message.setFrom("4Q <no-reply@qqqq.world>");
 
         // 이메일 전송
         mailSender.send(message);
@@ -100,5 +138,22 @@ public class EmailService {
         }
 
         return false;
+    }
+
+    private Optional<Cookie> getCookie(HttpServletRequest request, String name) {
+        if (request.getCookies() != null) {
+            return Arrays.stream(request.getCookies())
+                    .filter(cookie -> name.equals(cookie.getName()))
+                    .findFirst();
+        }
+        return Optional.empty();
+    }
+
+    private void setCookie(HttpServletResponse response, String name, String value, int maxAge) {
+        Cookie cookie = new Cookie(name, value);
+        cookie.setPath("/");
+        cookie.setMaxAge(maxAge);
+        cookie.setHttpOnly(true); // XSS 공격 방지
+        response.addCookie(cookie);
     }
 }

--- a/src/main/java/org/chunsik/pq/email/util/AESUtil.java
+++ b/src/main/java/org/chunsik/pq/email/util/AESUtil.java
@@ -1,0 +1,33 @@
+package org.chunsik.pq.email.util;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.SecretKeySpec;
+import java.util.Base64;
+
+public class AESUtil {
+
+    private static final String ALGORITHM = "AES";
+    private static final String TRANSFORMATION = "AES";
+
+    // 환경 변수나 안전한 키 관리 시스템으로 변경
+    private static final String SECRET_KEY = "abcdefgh12345678";
+
+    // 암호화 메서드
+    public static String encrypt(String input) throws Exception {
+        SecretKeySpec key = new SecretKeySpec(SECRET_KEY.getBytes(), ALGORITHM);
+        Cipher cipher = Cipher.getInstance(TRANSFORMATION);
+        cipher.init(Cipher.ENCRYPT_MODE, key);
+        byte[] encryptedBytes = cipher.doFinal(input.getBytes());
+        return Base64.getEncoder().encodeToString(encryptedBytes);
+    }
+
+    // 복호화 메서드
+    public static String decrypt(String input) throws Exception {
+        SecretKeySpec key = new SecretKeySpec(SECRET_KEY.getBytes(), ALGORITHM);
+        Cipher cipher = Cipher.getInstance(TRANSFORMATION);
+        cipher.init(Cipher.DECRYPT_MODE, key);
+        byte[] decodedBytes = Base64.getDecoder().decode(input);
+        byte[] decryptedBytes = cipher.doFinal(decodedBytes);
+        return new String(decryptedBytes);
+    }
+}

--- a/src/main/java/org/chunsik/pq/email/util/AESUtil.java
+++ b/src/main/java/org/chunsik/pq/email/util/AESUtil.java
@@ -9,7 +9,7 @@ public class AESUtil {
     private static final String ALGORITHM = "AES";
     private static final String TRANSFORMATION = "AES";
 
-    // 환경 변수나 안전한 키 관리 시스템으로 변경
+    // TODO : 환경 변수나 안전한 키 관리 시스템으로 변경
     private static final String SECRET_KEY = "abcdefgh12345678";
 
     // 암호화 메서드

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,16 +1,31 @@
 spring:
-  config:
-    activate:
-      on-profile: dev
   application:
     name: pq
-  datasource:
-    url: jdbc:mysql://${DB_URL}:3306/pq
-    username: ${DB_USER}
-    password: ${DB_PASSWORD}
   jpa:
     hibernate:
       ddl-auto: update
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect
+  datasource:
+    url: jdbc:mysql://${chunsik.db.url}:3306/pq
+    username: ${chunsik.db.user}
+    password: ${chunsik.db.password}
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${chunsik.mail.user}
+    password: ${chunsik.mail.password}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+            required: true
+          connectiontimeout: 5000
+          timeout: 5000
+          writetimeout: 5000
+auth-code-expiration-millis: 180000
+server:
+  port: 8080

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,21 +1,21 @@
 spring:
   application:
     name: pq
-  datasource:
-    url: jdbc:mysql://localhost:3306/chunsik_db
-    username: carter
-    password: carter
   jpa:
     hibernate:
       ddl-auto: update
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect
+  datasource:
+    url: jdbc:mysql://${chunsik.db.url}:3306/pq
+    username: ${chunsik.db.user}
+    password: ${chunsik.db.password}
   mail:
     host: smtp.gmail.com
     port: 587
-    username: kdg870918@gmail.com
-    password: pmxaaqtxhynfslpa
+    username: ${chunsik.mail.user}
+    password: ${chunsik.mail.password}
     properties:
       mail:
         smtp:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,0 +1,18 @@
+spring:
+  profiles:
+    active: dev
+---
+spring:
+  profiles:
+    active: prod
+---
+spring:
+  profiles:
+    active: local
+---
+spring:
+  application:
+    name: pq
+  config:
+    import:
+      - classpath:secrets.yaml

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,12 +2,30 @@ spring:
   application:
     name: pq
   datasource:
-    url: jdbc:mysql://localhost:3306/pq
-    username: pq_root
-    password: 123123
+    url: jdbc:mysql://localhost:3306/chunsik_db
+    username: carter
+    password: carter
   jpa:
     hibernate:
       ddl-auto: update
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: kdg870918@gmail.com
+    password: pmxaaqtxhynfslpa
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+            required: true
+          connectiontimeout: 5000
+          timeout: 5000
+          writetimeout: 5000
+auth-code-expiration-millis: 180000
+server:
+  port: 8080


### PR DESCRIPTION
### 개요
- 이메일 인증, 재전송 구현

### 리뷰어가 꼭 봐줬으면 하는 부분
- ERD Email_Confirm 테이블과 API 명세서에 맞춰서 구현
- 인증번호는 AES 알고리즘으로 암호화 해서 DB 저장, 복호화해서 검증
- createAt과 현재시간 비교해서 3분 초과하면 인증번호 만료 처리
- 동일 이메일에 대한 데이터가 있으면 추가하지 않고 기존의 데이터를 업데이트 하는 방식으로 구현
- 재전송요청은 다른 엔드포인트 API를 구현하지 않고 쿠키를 사용해서 쿠키에 요청횟수를 저장해서 쿠키 만료시간 30분 내에 최대 요청 횟수가 5회가 넘으면 429 TOO MANY REQUESTS 반환하도록 구현

-추가할 부분 : 민감정보 숨기기

### Jira ISSUE Keys
- PQ-48
   - PQ-89,PQ-90,PQ-91,PQ-92,PQ-93
- PQ-52