### PR TITLE
feat: 인기갤러리 기능 구현 완료

### DIFF
--- a/src/main/java/org/chunsik/pq/image/controller/PopularImageController.java
+++ b/src/main/java/org/chunsik/pq/image/controller/PopularImageController.java
@@ -1,0 +1,29 @@
+package org.chunsik.pq.image.controller;
+
+import lombok.RequiredArgsConstructor;
+
+import net.minidev.json.JSONUtil;
+import org.chunsik.pq.image.dto.ImageResponseDto;
+import org.chunsik.pq.image.service.ImageService;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/images")
+public class PopularImageController {
+
+    private final ImageService service;
+
+    @GetMapping("/popular")
+    public List<ImageResponseDto> getTopPhotoBackgrounds() {
+        return service.getTopPhotoBackgrounds().stream()
+                .map(data -> new ImageResponseDto((String) data[0]))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/org/chunsik/pq/image/dto/ImageResponseDto.java
+++ b/src/main/java/org/chunsik/pq/image/dto/ImageResponseDto.java
@@ -1,0 +1,12 @@
+package org.chunsik.pq.image.dto;
+
+import lombok.RequiredArgsConstructor;
+import lombok.Getter;
+
+@RequiredArgsConstructor
+@Getter
+public class ImageResponseDto {
+
+    private final String imagePath;
+
+}

--- a/src/main/java/org/chunsik/pq/image/model/PhotoBackground.java
+++ b/src/main/java/org/chunsik/pq/image/model/PhotoBackground.java
@@ -1,0 +1,27 @@
+package org.chunsik.pq.image.model;
+
+import jakarta.persistence.*;
+
+import lombok.Getter;
+
+@Getter
+@Entity
+@Table(name = "photo_background")
+public class PhotoBackground {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "image_path")
+    private String imagePath;
+
+    @Column(name = "user_id")
+    private Long userId;
+
+    @Column(name = "size")
+    private Integer size;
+
+    @Column(name = "category_id")
+    private Long categoryId;
+}

--- a/src/main/java/org/chunsik/pq/image/model/TagPhotoBackground.java
+++ b/src/main/java/org/chunsik/pq/image/model/TagPhotoBackground.java
@@ -1,0 +1,28 @@
+package org.chunsik.pq.image.model;
+
+import jakarta.persistence.*;
+
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Table(name = "tag_photo_background")
+public class TagPhotoBackground {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "tag_id")
+    private Long tagId;
+
+    @ManyToOne
+    @JoinColumn(name = "photo_background_id", insertable = false, updatable = false)
+    private PhotoBackground photoBackground;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+}

--- a/src/main/java/org/chunsik/pq/image/repository/ImageRepository.java
+++ b/src/main/java/org/chunsik/pq/image/repository/ImageRepository.java
@@ -1,0 +1,21 @@
+package org.chunsik.pq.image.repository;
+
+import org.chunsik.pq.image.model.TagPhotoBackground;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ImageRepository extends JpaRepository<TagPhotoBackground, Long> {
+
+    @Query(value = "SELECT pb.image_path, COUNT(tpb.id) as count " +
+            "FROM tag_photo_background tpb " +
+            "JOIN photo_background pb ON tpb.photo_background_id = pb.id " +
+            "WHERE tpb.created_at >= NOW() - INTERVAL 1 DAY " +
+            "GROUP BY pb.image_path " +
+            "ORDER BY count DESC", nativeQuery = true)
+    List<Object[]> findTopPhotoBackgrounds();
+}

--- a/src/main/java/org/chunsik/pq/image/service/ImageService.java
+++ b/src/main/java/org/chunsik/pq/image/service/ImageService.java
@@ -1,0 +1,19 @@
+package org.chunsik.pq.image.service;
+
+import lombok.RequiredArgsConstructor;
+
+import org.chunsik.pq.image.repository.ImageRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class ImageService {
+
+    private final ImageRepository repository;
+
+    public List<Object[]> getTopPhotoBackgrounds() {
+        return repository.findTopPhotoBackgrounds();
+    }
+}


### PR DESCRIPTION
### 개요

- 24시간 내 생성횟수가 많은 이미지 순으로 image_path 리스트 보내주는 기능 구현

### 리뷰어가 꼭 봐줬으면 하는 부분

- 배경이미지 테이블과 태그_배경이미지 테이블만 연결해서 구현해놓아서 다른 기능에서 다른 테이블과 연결할때 엔티티 수정해야 합니다.
- 24시간 내 생성이미지만 검색하기 위해서 nativeQuery(INTERVAL 1 DAY) 사용했습니다.

### Jira ISSUE Keys

- PQ-33