### PR TITLE
refactor : 이메일 인증번호 검증 API 요청형식 변경

### DIFF
--- a/src/main/java/org/chunsik/pq/email/controller/EmailController.java
+++ b/src/main/java/org/chunsik/pq/email/controller/EmailController.java
@@ -11,8 +11,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.Map;
-
 @RestController
 @RequestMapping("/users/email")
 @RequiredArgsConstructor
@@ -32,7 +30,9 @@ public class EmailController {
 
     // 인증번호 검증
     @PatchMapping("/verification")
-    public ResponseEntity<String> verifyEmail(@RequestParam String email, @RequestParam String code) {
+    public ResponseEntity<String> verifyEmail(@RequestBody EmailConfirmRequestDTO dto) {
+        String email = dto.getEmail();
+        String code = dto.getCode();
         if (email.isEmpty() || code.isEmpty()) {
             return new ResponseEntity<>("Invalid request format.", HttpStatus.BAD_REQUEST);
         }

--- a/src/main/java/org/chunsik/pq/email/dto/EmailConfirmRequestDTO.java
+++ b/src/main/java/org/chunsik/pq/email/dto/EmailConfirmRequestDTO.java
@@ -5,4 +5,5 @@ import lombok.Data;
 @Data
 public class EmailConfirmRequestDTO {
     private String email;
+    private String code;
 }


### PR DESCRIPTION
### 개요
- RequestParams로 받던 요청을 RequestBody로 변경
- 변경사항에 맞춰서 DTO도 변경