### PR TITLE
Feat: 배경이미지 생성 서비스 로직 수정

### DIFF
--- a/src/main/java/org/chunsik/pq/generate/controller/GenerateController.java
+++ b/src/main/java/org/chunsik/pq/generate/controller/GenerateController.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 
@@ -20,7 +21,17 @@ public class GenerateController {
 
     @PostMapping("/generate")
     public GenerateResponseDTO generateImage(@RequestBody GenerateImageDTO generateImageDTO) throws IOException {
-        return generateService.generateAndUploadImage(generateImageDTO);
+        return generateService.generateImage(generateImageDTO);
+    }
+
+    @PostMapping("/create")
+    public void createImage(@RequestPart(value = "ticketImage") MultipartFile ticketImage,
+                            @RequestPart(value = "backgroundImageUrl") String backgroundImageUrl,
+                            @RequestPart(value = "shortenUrlId") String shortenUrlId,
+                            @RequestPart(value = "title") String title,
+                            @RequestPart(value = "generateImageDTO") GenerateImageDTO generateImageDTO
+    ) throws IOException {
+        generateService.createImage(ticketImage, backgroundImageUrl, shortenUrlId, title, generateImageDTO);
     }
 
     @ExceptionHandler(IOException.class)

--- a/src/main/java/org/chunsik/pq/generate/controller/GenerateController.java
+++ b/src/main/java/org/chunsik/pq/generate/controller/GenerateController.java
@@ -1,23 +1,23 @@
 package org.chunsik.pq.generate.controller;
 
 import io.sentry.Sentry;
+import lombok.RequiredArgsConstructor;
+import org.chunsik.pq.generate.dto.GenerateApiRequestDTO;
 import org.chunsik.pq.generate.dto.GenerateImageDTO;
 import org.chunsik.pq.generate.dto.GenerateResponseDTO;
 import org.chunsik.pq.generate.service.GenerateService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.util.Map;
 
+@RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/v1")
 public class GenerateController {
-
-    @Autowired
-    private GenerateService generateService;
+    private final GenerateService generateService;
 
     @PostMapping("/generate")
     public GenerateResponseDTO generateImage(@RequestBody GenerateImageDTO generateImageDTO) throws IOException {
@@ -25,13 +25,9 @@ public class GenerateController {
     }
 
     @PostMapping("/create")
-    public void createImage(@RequestPart(value = "ticketImage") MultipartFile ticketImage,
-                            @RequestPart(value = "backgroundImageUrl") String backgroundImageUrl,
-                            @RequestPart(value = "shortenUrlId") String shortenUrlId,
-                            @RequestPart(value = "title") String title,
-                            @RequestPart(value = "generateImageDTO") GenerateImageDTO generateImageDTO
-    ) throws IOException {
-        generateService.createImage(ticketImage, backgroundImageUrl, shortenUrlId, title, generateImageDTO);
+    public Map<String, String> createImage(@ModelAttribute GenerateApiRequestDTO dto) throws IOException {
+        generateService.createImage(dto);
+        return Map.of("message", "Success");
     }
 
     @ExceptionHandler(IOException.class)

--- a/src/main/java/org/chunsik/pq/generate/dto/GenerateApiRequestDTO.java
+++ b/src/main/java/org/chunsik/pq/generate/dto/GenerateApiRequestDTO.java
@@ -1,0 +1,21 @@
+package org.chunsik.pq.generate.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@NoArgsConstructor
+@Getter
+@Setter
+public class GenerateApiRequestDTO {
+    private MultipartFile ticketImage;
+    private String backgroundImageUrl;
+    private String shortenUrlId;
+    private String title;
+    private List<String> tags;
+    private Long userId;
+    private String categoryId;
+}

--- a/src/main/java/org/chunsik/pq/generate/manager/OpenAIManager.java
+++ b/src/main/java/org/chunsik/pq/generate/manager/OpenAIManager.java
@@ -44,8 +44,11 @@ public class OpenAIManager {
 
         ResponseEntity<GenerateApiResponseDTO> response = restTemplate.exchange(url, HttpMethod.POST, entity, GenerateApiResponseDTO.class);
 
+
+        String responseUrl = response.getBody().getData().get(0).get("url");
+
         return GenerateResponseDTO.builder()
-                .url(response.getBody().getData().get(0).get("url"))
+                .url(responseUrl)
                 .build();
     }
 }

--- a/src/main/java/org/chunsik/pq/generate/service/GenerateService.java
+++ b/src/main/java/org/chunsik/pq/generate/service/GenerateService.java
@@ -4,13 +4,22 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.chunsik.pq.generate.dto.GenerateImageDTO;
 import org.chunsik.pq.generate.dto.GenerateResponseDTO;
+import org.chunsik.pq.generate.manager.KarloManager;
 import org.chunsik.pq.generate.manager.OpenAIManager;
 import org.chunsik.pq.generate.model.BackgroundImage;
 import org.chunsik.pq.generate.repository.BackgroundImageRepository;
+import org.chunsik.pq.login.repository.UserRepository;
+import org.chunsik.pq.model.User;
 import org.chunsik.pq.s3.dto.S3UploadDTO;
 import org.chunsik.pq.s3.dto.S3UploadResponseDTO;
 import org.chunsik.pq.s3.manager.S3Manager;
+import org.chunsik.pq.s3.model.Ticket;
+import org.chunsik.pq.s3.repository.TicketRepository;
+import org.chunsik.pq.shortenurl.model.ShortenURL;
+import org.chunsik.pq.shortenurl.repository.ShortenUrlRepository;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
@@ -18,18 +27,81 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
 public class GenerateService {
     private final S3Manager s3Manager;
     private final OpenAIManager openAIManager;
+    private final KarloManager karloManager;
     private final BackgroundImageRepository backgroundImageRepository;
+    private final ShortenUrlRepository shortenURLRepository;
+    private final UserRepository userRepository;
+    private final TicketRepository ticketRepository;
+
+    @Value("${cloud.aws.s3.generate}")
+    private String generate;
+
+    @Value("${cloud.aws.s3.ticket}")
+    private String ticket;
 
     @Transactional
-    public GenerateResponseDTO generateAndUploadImage(GenerateImageDTO generateImageDTO) throws IOException {
+    public GenerateResponseDTO generateImage(GenerateImageDTO generateImageDTO) throws IOException {
         // 이미지 생성
-        GenerateResponseDTO generateResponseDTO = openAIManager.generateImage(generateImageDTO.getTags());
+        return openAIManager.generateImage(generateImageDTO.getTags());
+    }
+
+    @Transactional
+    public void createImage(MultipartFile ticketImage, String backgroundImageUrl, String shortenUrlId, String title, GenerateImageDTO generateImageDTO) throws IOException, NoSuchElementException {
+        File jpgFile = downloadJpg(backgroundImageUrl);
+
+        S3UploadResponseDTO s3UploadResponseDTO = s3Manager.uploadFile(jpgFile, generate);
+
+        BackgroundImage.BackgroundImageBuilder builder = BackgroundImage.builder()
+                .size(jpgFile.length())
+                .url(s3UploadResponseDTO.getS3Url())
+                .userId(generateImageDTO.getUserId())
+                .categoryId(generateImageDTO.getCategoryId());
+
+        List<String> tags = generateImageDTO.getTags();
+
+        switch (tags.size()) {
+            case 3:
+                builder.thirdTag(tags.get(2));
+            case 2:
+                builder.secondTag(tags.get(1));
+            case 1:
+                builder.firstTag(tags.get(0));
+        }
+
+        BackgroundImage backgroundImage = builder.build();
+
+        backgroundImageRepository.save(backgroundImage);
+
+        // 티켓 이미지 업로드 및 저장
+        File file = new File("/tmp/" + UUID.randomUUID().toString() + ".jpg");
+        ticketImage.transferTo(file);
+
+        s3UploadResponseDTO = s3Manager.uploadFile(file, ticket);
+
+        Optional<ShortenURL> shortenURL = shortenURLRepository.findById(Long.valueOf(shortenUrlId));
+        if (shortenURL.isEmpty()) {
+            throw new NoSuchElementException();
+        }
+
+        Optional<User> user = userRepository.findById(generateImageDTO.getUserId());
+        if (user.isEmpty()) {
+            throw new NoSuchElementException();
+        }
+        Ticket ticket = new Ticket(user.get(), shortenURL.get(), backgroundImage, title, s3UploadResponseDTO.getS3Url());
+        ticketRepository.save(ticket);
+    }
+
+    public GenerateResponseDTO generateImageKarlo(GenerateImageDTO generateImageDTO) throws IOException {
+        GenerateResponseDTO generateResponseDTO = karloManager.generateImage(generateImageDTO.getTags());
 
         // URL에서 파일 이름만 추출
         File jpgFile = downloadJpg(generateResponseDTO.getUrl());
@@ -43,8 +115,7 @@ public class GenerateService {
                 .categoryId(generateImageDTO.getCategoryId())
                 .build();
 
-        S3UploadResponseDTO s3UploadResponseDTO = s3Manager.uploadFile(s3UploadDTO);
-
+        S3UploadResponseDTO s3UploadResponseDTO = s3Manager.uploadFile(s3UploadDTO.getFile(), generate);
 
         // DB에 저장
         BackgroundImage.BackgroundImageBuilder builder = BackgroundImage.builder()
@@ -71,7 +142,7 @@ public class GenerateService {
         return new GenerateResponseDTO(backgroundImage.getUrl());
     }
 
-    // 이미지 변환 부분
+    // url 이미지를 File로 매핑해 리턴하는 메소드
     private File downloadJpg(String imageUrl) throws IOException {
         BufferedImage image = ImageIO.read(new URL(imageUrl));
         String fileName = imageUrl.substring(imageUrl.lastIndexOf('/') + 1);    // 파일명만 추출

--- a/src/main/java/org/chunsik/pq/generate/service/GenerateService.java
+++ b/src/main/java/org/chunsik/pq/generate/service/GenerateService.java
@@ -2,6 +2,7 @@ package org.chunsik.pq.generate.service;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.chunsik.pq.generate.dto.GenerateApiRequestDTO;
 import org.chunsik.pq.generate.dto.GenerateImageDTO;
 import org.chunsik.pq.generate.dto.GenerateResponseDTO;
 import org.chunsik.pq.generate.manager.OpenAIManager;
@@ -46,24 +47,37 @@ public class GenerateService {
     private String ticket;
 
     @Transactional
-    public GenerateResponseDTO generateImage(GenerateImageDTO generateImageDTO) throws IOException {
+    public GenerateResponseDTO generateImage(GenerateImageDTO generateImageDTO) {
         // 이미지 생성
         return openAIManager.generateImage(generateImageDTO.getTags());
     }
 
     @Transactional
-    public void createImage(MultipartFile ticketImage, String backgroundImageUrl, String shortenUrlId, String title, GenerateImageDTO generateImageDTO) throws IOException, NoSuchElementException {
+    public void createImage(GenerateApiRequestDTO dto) throws IOException {
+        this.createImage(dto.getTicketImage(), dto.getBackgroundImageUrl(),
+                dto.getShortenUrlId(), dto.getTitle(),
+                dto.getTags(), dto.getUserId(), dto.getCategoryId()
+        );
+    }
+
+    @Transactional
+    public void createImage(
+            MultipartFile ticketImage, String backgroundImageUrl,
+            String shortenUrlId, String title,
+            List<String> tags, Long userId, String categoryId
+    ) throws IOException, NoSuchElementException {
+        // 배경이미지 다운로드
         File jpgFile = downloadJpg(backgroundImageUrl);
 
+        // 배경이미지 S3 업로드
         S3UploadResponseDTO s3UploadResponseDTO = s3Manager.uploadFile(jpgFile, generate);
 
+        // 배경이미지 Insert
         BackgroundImage.BackgroundImageBuilder builder = BackgroundImage.builder()
                 .size(jpgFile.length())
                 .url(s3UploadResponseDTO.getS3Url())
-                .userId(generateImageDTO.getUserId())
-                .categoryId(generateImageDTO.getCategoryId());
-
-        List<String> tags = generateImageDTO.getTags();
+                .userId(userId)
+                .categoryId(categoryId);
 
         switch (tags.size()) {
             case 3:
@@ -75,23 +89,24 @@ public class GenerateService {
         }
 
         BackgroundImage backgroundImage = builder.build();
-
         backgroundImageRepository.save(backgroundImage);
 
-        // 티켓 이미지 업로드 및 저장
-        File file = new File("/tmp/" + UUID.randomUUID().toString() + ".jpg");
+        // 티켓 이미지 S3 업로드
+        File file = new File("/tmp/" + UUID.randomUUID() + ".jpg");
         ticketImage.transferTo(file);
 
         s3UploadResponseDTO = s3Manager.uploadFile(file, ticket);
 
+        // 단축 URL
         Optional<ShortenURL> shortenURL = shortenURLRepository.findById(Long.valueOf(shortenUrlId));
         if (shortenURL.isEmpty()) {
-            throw new NoSuchElementException();
+            throw new NoSuchElementException("No shorten URL found for shortenUrlId: " + shortenUrlId);
         }
 
-        Optional<User> user = userRepository.findById(generateImageDTO.getUserId());
+        // 로그인 사용자
+        Optional<User> user = userRepository.findById(userId);
         if (user.isEmpty()) {
-            throw new NoSuchElementException();
+            throw new NoSuchElementException("No user found for userId: " + userId);
         }
         Ticket ticket = new Ticket(user.get(), shortenURL.get(), backgroundImage, title, s3UploadResponseDTO.getS3Url());
         ticketRepository.save(ticket);

--- a/src/main/java/org/chunsik/pq/generate/service/GenerateService.java
+++ b/src/main/java/org/chunsik/pq/generate/service/GenerateService.java
@@ -4,13 +4,11 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.chunsik.pq.generate.dto.GenerateImageDTO;
 import org.chunsik.pq.generate.dto.GenerateResponseDTO;
-import org.chunsik.pq.generate.manager.KarloManager;
 import org.chunsik.pq.generate.manager.OpenAIManager;
 import org.chunsik.pq.generate.model.BackgroundImage;
 import org.chunsik.pq.generate.repository.BackgroundImageRepository;
 import org.chunsik.pq.login.repository.UserRepository;
 import org.chunsik.pq.model.User;
-import org.chunsik.pq.s3.dto.S3UploadDTO;
 import org.chunsik.pq.s3.dto.S3UploadResponseDTO;
 import org.chunsik.pq.s3.manager.S3Manager;
 import org.chunsik.pq.s3.model.Ticket;
@@ -36,7 +34,6 @@ import java.util.UUID;
 public class GenerateService {
     private final S3Manager s3Manager;
     private final OpenAIManager openAIManager;
-    private final KarloManager karloManager;
     private final BackgroundImageRepository backgroundImageRepository;
     private final ShortenUrlRepository shortenURLRepository;
     private final UserRepository userRepository;
@@ -98,48 +95,6 @@ public class GenerateService {
         }
         Ticket ticket = new Ticket(user.get(), shortenURL.get(), backgroundImage, title, s3UploadResponseDTO.getS3Url());
         ticketRepository.save(ticket);
-    }
-
-    public GenerateResponseDTO generateImageKarlo(GenerateImageDTO generateImageDTO) throws IOException {
-        GenerateResponseDTO generateResponseDTO = karloManager.generateImage(generateImageDTO.getTags());
-
-        // URL에서 파일 이름만 추출
-        File jpgFile = downloadJpg(generateResponseDTO.getUrl());
-
-        // S3 업로드
-        S3UploadDTO s3UploadDTO = S3UploadDTO.builder()
-                .file(jpgFile)
-                .size(jpgFile.length())
-                .tags(generateImageDTO.getTags())
-                .userId(generateImageDTO.getUserId())
-                .categoryId(generateImageDTO.getCategoryId())
-                .build();
-
-        S3UploadResponseDTO s3UploadResponseDTO = s3Manager.uploadFile(s3UploadDTO.getFile(), generate);
-
-        // DB에 저장
-        BackgroundImage.BackgroundImageBuilder builder = BackgroundImage.builder()
-                .userId(s3UploadDTO.getUserId())
-                .url(s3UploadResponseDTO.getS3Url())
-                .categoryId(s3UploadDTO.getCategoryId())
-                .size(s3UploadDTO.getSize());
-
-        List<String> tags = s3UploadDTO.getTags();
-
-        switch (tags.size()) {
-            case 3:
-                builder.thirdTag(tags.get(2));
-            case 2:
-                builder.secondTag(tags.get(1));
-            case 1:
-                builder.firstTag(tags.get(0));
-        }
-
-        BackgroundImage backgroundImage = builder.build();
-
-        backgroundImageRepository.save(backgroundImage);
-
-        return new GenerateResponseDTO(backgroundImage.getUrl());
     }
 
     // url 이미지를 File로 매핑해 리턴하는 메소드

--- a/src/main/java/org/chunsik/pq/s3/manager/S3Manager.java
+++ b/src/main/java/org/chunsik/pq/s3/manager/S3Manager.java
@@ -1,7 +1,6 @@
 package org.chunsik.pq.s3.manager;
 
 import lombok.RequiredArgsConstructor;
-import org.chunsik.pq.s3.dto.S3UploadDTO;
 import org.chunsik.pq.s3.dto.S3UploadResponseDTO;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -10,6 +9,8 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
+import java.io.File;
+import java.io.IOException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
@@ -25,9 +26,8 @@ public class S3Manager {
     @Value("${cloud.aws.s3.bucket}")
     private String bucketName;
 
-    public S3UploadResponseDTO uploadFile(S3UploadDTO s3UploadDTO) {
-        String filename = UUID.randomUUID() + ".jpg"; // UUID로 대체하여 고유한 파일 이름을 생성
-        String fullFileName = "generate/" + filename;
+    public S3UploadResponseDTO uploadFile(File file, String folder) throws IOException {
+        String fullFileName = generateFileName(folder); // 이미지 생성 ai에 따라 karlo 또는 generate(OpenAI)
 
         PutObjectRequest putObjectRequest = PutObjectRequest.builder()
                 .bucket(bucketName)
@@ -37,9 +37,14 @@ public class S3Manager {
 
         String s3Url = makeS3Url(fullFileName);
 
-        s3Client.putObject(putObjectRequest, RequestBody.fromFile(s3UploadDTO.getFile()));
+        s3Client.putObject(putObjectRequest, RequestBody.fromFile(file));
 
         return new S3UploadResponseDTO(fullFileName, s3Url);
+    }
+
+    private String generateFileName(String prefix) {
+        String filename = UUID.randomUUID() + ".jpg"; // UUID로 대체하여 고유한 파일 이름을 생성
+        return prefix + filename;
     }
 
     private String makeS3Url(String fullFileName) {

--- a/src/main/java/org/chunsik/pq/s3/manager/S3Manager.java
+++ b/src/main/java/org/chunsik/pq/s3/manager/S3Manager.java
@@ -44,7 +44,7 @@ public class S3Manager {
 
     private String generateFileName(String prefix) {
         String filename = UUID.randomUUID() + ".jpg"; // UUID로 대체하여 고유한 파일 이름을 생성
-        return prefix + filename;
+        return prefix + "/" + filename;
     }
 
     private String makeS3Url(String fullFileName) {

--- a/src/main/java/org/chunsik/pq/s3/model/Ticket.java
+++ b/src/main/java/org/chunsik/pq/s3/model/Ticket.java
@@ -1,0 +1,46 @@
+package org.chunsik.pq.s3.model;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.chunsik.pq.generate.model.BackgroundImage;
+import org.chunsik.pq.model.User;
+import org.chunsik.pq.shortenurl.model.ShortenURL;
+
+@NoArgsConstructor
+@Getter
+@Entity
+@Table(name = "Ticket")
+public class Ticket {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "url_id", nullable = false)
+    private ShortenURL url;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "background_id", nullable = false)
+    private BackgroundImage backgroundImage;
+
+    @Column(name = "title")
+    private String title;
+
+    @Column(name = "image_path")
+    private String imagePath;
+
+    public Ticket(User user, ShortenURL url, BackgroundImage backgroundImage, String title, String imagePath) {
+        this.user = user;
+        this.url = url;
+        this.backgroundImage = backgroundImage;
+        this.title = title;
+        this.imagePath = imagePath;
+    }
+}
+

--- a/src/main/java/org/chunsik/pq/s3/repository/TicketRepository.java
+++ b/src/main/java/org/chunsik/pq/s3/repository/TicketRepository.java
@@ -1,0 +1,7 @@
+package org.chunsik.pq.s3.repository;
+
+import org.chunsik.pq.s3.model.Ticket;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TicketRepository extends JpaRepository<Ticket, Long> {
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -42,6 +42,8 @@ cloud:
   aws:
     s3:
       bucket: ${chunsik.s3.bucket}
+      generate: generate
+      ticket: ticket
     region:
       static: ap-northeast-2
     stack:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -43,6 +43,9 @@ cloud:
   aws:
     s3:
       bucket: ${chunsik.s3.bucket}
+      generate: ${chunsik.s3.generate}
+      ticket: ${chunsik.s3.ticket}
+
     region:
       static: ap-northeast-2
     stack:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -43,8 +43,8 @@ cloud:
   aws:
     s3:
       bucket: ${chunsik.s3.bucket}
-      generate: ${chunsik.s3.generate}
-      ticket: ${chunsik.s3.ticket}
+      generate: generate
+      ticket: ticket
 
     region:
       static: ap-northeast-2

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -42,6 +42,8 @@ cloud:
   aws:
     s3:
       bucket: ${chunsik.s3.bucket}
+      generate: generate
+      ticket: ticket
     region:
       static: ap-northeast-2
     stack:


### PR DESCRIPTION
# Feat: 배경이미지 생성 서비스 로직 수정

### 개요
> GenerateService의 createImage 기능 구현 (배경, 티켓 이미지 동시 저장)
S3Manager의 uploadFile 함수 매개변수에 folder 추가(배경,티켓 폴더 구분 야물 값)
ticket과 ticket repository 구현


### 리뷰어가 꼭 봐줬으면 하는 부분
> createImage의 매개변수와 로직이 적절한지 봐주시면 감사하겠습니다