### PR TITLE
Feat: 티켓 엔티티, 배경 이미지 요청 DTO 수정

### DIFF
--- a/src/main/java/org/chunsik/pq/generate/dto/GenerateApiRequestDTO.java
+++ b/src/main/java/org/chunsik/pq/generate/dto/GenerateApiRequestDTO.java
@@ -13,7 +13,7 @@ import java.util.List;
 public class GenerateApiRequestDTO {
     private MultipartFile ticketImage;
     private String backgroundImageUrl;
-    private String shortenUrlId;
+    private Long shortenUrlId;
     private String title;
     private List<String> tags;
     private Long userId;

--- a/src/main/java/org/chunsik/pq/generate/service/GenerateService.java
+++ b/src/main/java/org/chunsik/pq/generate/service/GenerateService.java
@@ -63,7 +63,7 @@ public class GenerateService {
     @Transactional
     public void createImage(
             MultipartFile ticketImage, String backgroundImageUrl,
-            String shortenUrlId, String title,
+            Long shortenUrlId, String title,
             List<String> tags, Long userId, String categoryId
     ) throws IOException, NoSuchElementException {
         // 배경이미지 다운로드
@@ -98,7 +98,7 @@ public class GenerateService {
         s3UploadResponseDTO = s3Manager.uploadFile(file, ticket);
 
         // 단축 URL
-        Optional<ShortenURL> shortenURL = shortenURLRepository.findById(Long.valueOf(shortenUrlId));
+        Optional<ShortenURL> shortenURL = shortenURLRepository.findById(shortenUrlId);
         if (shortenURL.isEmpty()) {
             throw new NoSuchElementException("No shorten URL found for shortenUrlId: " + shortenUrlId);
         }

--- a/src/main/java/org/chunsik/pq/s3/model/Ticket.java
+++ b/src/main/java/org/chunsik/pq/s3/model/Ticket.java
@@ -7,6 +7,8 @@ import org.chunsik.pq.generate.model.BackgroundImage;
 import org.chunsik.pq.model.User;
 import org.chunsik.pq.shortenurl.model.ShortenURL;
 
+import java.time.LocalDateTime;
+
 @NoArgsConstructor
 @Getter
 @Entity
@@ -35,12 +37,16 @@ public class Ticket {
     @Column(name = "image_path")
     private String imagePath;
 
+    @Column(name = "created_at", columnDefinition = "TIMESTAMP")
+    private LocalDateTime createdAt;
+
     public Ticket(User user, ShortenURL url, BackgroundImage backgroundImage, String title, String imagePath) {
         this.user = user;
         this.url = url;
         this.backgroundImage = backgroundImage;
         this.title = title;
         this.imagePath = imagePath;
+        this.createdAt = LocalDateTime.now();
     }
 }
 


### PR DESCRIPTION
# Feat: 티켓 엔티티, DTO 수정

### 개요
> 티켓 엔티티 생성일자 칼럼 추가 및 배경 이미지 요청 DTO 수정

### 리뷰어가 꼭 봐줬으면 하는 부분
> ERD 상에는 없지만 생성일자가 필요할 것 같아서 Ticket 엔티티에 create_at 칼럼을 추가했습니다.
> GenerateApiRequestDTO의 shortenUrlId의 타입을 String에서 Long으로 변경했습니다. (String으로 잘 못 바뀌였던 것 같습니다.)
> GenerateApiRequestDTO의 수정으로 인해 createImage의 메소드 시그니쳐 변경
