### PR TITLE
Refactor: 단축 URL DB 저장 방식 수정

### DIFF
--- a/src/main/java/org/chunsik/pq/shortenurl/controller/ShortenUrlController.java
+++ b/src/main/java/org/chunsik/pq/shortenurl/controller/ShortenUrlController.java
@@ -28,11 +28,9 @@ public class ShortenUrlController {
     private final ShortenUrlService shortenUrlService;
 
     @PostMapping("/short")
-    public ResponseConvertUrlDTO urlConvert(@RequestBody @Valid RequestConvertUrlDTO requestConvertUrlDTO,
-                                            HttpServletRequest request) {
+    public ResponseConvertUrlDTO urlConvert(@RequestBody @Valid RequestConvertUrlDTO requestConvertUrlDTO) {
         String url = requestConvertUrlDTO.getSrcUrl();
-
-        return shortenUrlService.convertToShortUrl(url, request.getScheme() + "://" + request.getServerName());
+        return shortenUrlService.convertToShortUrl(url);
     }
 
     @GetMapping("/s/{dest_url}")

--- a/src/main/java/org/chunsik/pq/shortenurl/exception/ErrorCode.java
+++ b/src/main/java/org/chunsik/pq/shortenurl/exception/ErrorCode.java
@@ -5,7 +5,7 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 public enum ErrorCode {
-    REACH_LIMIT(HttpStatus.NOT_EXTENDED, "URL 단축에 실패했습니다."),
+    REACH_LIMIT(HttpStatus.INTERNAL_SERVER_ERROR, "URL 단축에 실패했습니다."),
     FORMAT_NOT_MATCH(HttpStatus.BAD_REQUEST, "URL 형식이 올바르지 않습니다."),
     SYNTAX_NOT_MATCH(HttpStatus.BAD_REQUEST, "연결된 URL이 없습니다.");
 

--- a/src/main/java/org/chunsik/pq/shortenurl/exception/ErrorCode.java
+++ b/src/main/java/org/chunsik/pq/shortenurl/exception/ErrorCode.java
@@ -5,7 +5,7 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 public enum ErrorCode {
-    REACH_LIMIT(HttpStatus.NOT_FOUND, "URL 단축에 실패했습니다."),
+    REACH_LIMIT(HttpStatus.NOT_EXTENDED, "URL 단축에 실패했습니다."),
     FORMAT_NOT_MATCH(HttpStatus.BAD_REQUEST, "URL 형식이 올바르지 않습니다."),
     SYNTAX_NOT_MATCH(HttpStatus.BAD_REQUEST, "연결된 URL이 없습니다.");
 

--- a/src/main/java/org/chunsik/pq/shortenurl/model/ShortenURL.java
+++ b/src/main/java/org/chunsik/pq/shortenurl/model/ShortenURL.java
@@ -16,6 +16,7 @@ public class ShortenURL {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Lob
     @Column(name = "src_url", columnDefinition = "TEXT")
     private String srcURL;
 

--- a/src/main/java/org/chunsik/pq/shortenurl/model/ShortenURL.java
+++ b/src/main/java/org/chunsik/pq/shortenurl/model/ShortenURL.java
@@ -16,7 +16,7 @@ public class ShortenURL {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "src_url")
+    @Column(name = "src_url", columnDefinition = "TEXT")
     private String srcURL;
 
     @Column(name = "dest_url")

--- a/src/main/java/org/chunsik/pq/shortenurl/model/ShortenURL.java
+++ b/src/main/java/org/chunsik/pq/shortenurl/model/ShortenURL.java
@@ -5,8 +5,6 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.net.URL;
-import java.sql.Timestamp;
 import java.time.LocalDateTime;
 
 @NoArgsConstructor

--- a/src/main/java/org/chunsik/pq/shortenurl/service/ShortenUrlService.java
+++ b/src/main/java/org/chunsik/pq/shortenurl/service/ShortenUrlService.java
@@ -29,10 +29,12 @@ public class ShortenUrlService {
             if (count == END_OF_DUPLICATION_TRY) throw new URLConvertReachTheLimitException(ErrorCode.REACH_LIMIT);
         }
 
-        ShortenURL shortenURL = new ShortenURL(srcUrl, destUrl, LocalDateTime.now());
+        String addPrefix = PREFIX_DOMAIN_URL + destUrl;
+
+        ShortenURL shortenURL = new ShortenURL(srcUrl, addPrefix, LocalDateTime.now());
         Long id = shortenUrlRepository.save(shortenURL).getId();
 
-        return new ResponseConvertUrlDTO(id, destUrl);
+        return new ResponseConvertUrlDTO(id, addPrefix);
     }
 
     public String responseShortUrl(String destUrl) {

--- a/src/main/java/org/chunsik/pq/shortenurl/service/ShortenUrlService.java
+++ b/src/main/java/org/chunsik/pq/shortenurl/service/ShortenUrlService.java
@@ -37,8 +37,6 @@ public class ShortenUrlService {
 
     public String responseShortUrl(String destUrl) {
         ShortenURL shortenURL = shortenUrlRepository.findByDestURL(destUrl);
-        System.out.println(shortenURL.getSrcURL());
-        System.out.println(shortenURL.getDestURL());
         return shortenURL.getSrcURL();
     }
 

--- a/src/main/java/org/chunsik/pq/shortenurl/service/ShortenUrlService.java
+++ b/src/main/java/org/chunsik/pq/shortenurl/service/ShortenUrlService.java
@@ -7,6 +7,7 @@ import org.chunsik.pq.shortenurl.exception.URLConvertReachTheLimitException;
 import org.chunsik.pq.shortenurl.manager.ShortenUrlManager;
 import org.chunsik.pq.shortenurl.model.ShortenURL;
 import org.chunsik.pq.shortenurl.repository.ShortenUrlRepository;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
@@ -17,10 +18,13 @@ import static org.chunsik.pq.shortenurl.util.constant.ShortenUrlConstant.*;
 @RequiredArgsConstructor
 public class ShortenUrlService {
 
+    @Value("${chunsik.server.url}")
+    private String serverDomain;
+
     private final ShortenUrlRepository shortenUrlRepository;
     private final ShortenUrlManager shortenUrlManager;
 
-    public ResponseConvertUrlDTO convertToShortUrl(String srcUrl, String serverName) {
+    public ResponseConvertUrlDTO convertToShortUrl(String srcUrl) {
         String destUrl = INIT_STRING_SET;
 
         for (int count = INIT_NUMBER; count < END_OF_TRY_NUMBER; count++) {
@@ -29,12 +33,11 @@ public class ShortenUrlService {
             if (count == END_OF_DUPLICATION_TRY) throw new URLConvertReachTheLimitException(ErrorCode.REACH_LIMIT);
         }
 
-        String addPrefix = PREFIX_DOMAIN_URL + destUrl;
-
-        ShortenURL shortenURL = new ShortenURL(srcUrl, addPrefix, LocalDateTime.now());
+        ShortenURL shortenURL = new ShortenURL(srcUrl, destUrl, LocalDateTime.now());
         Long id = shortenUrlRepository.save(shortenURL).getId();
 
-        return new ResponseConvertUrlDTO(id, addPrefix);
+        String fullQualifiedShortUrl = serverDomain + "/s/" + destUrl;
+        return new ResponseConvertUrlDTO(id, fullQualifiedShortUrl);
 
     }
 

--- a/src/main/java/org/chunsik/pq/shortenurl/util/constant/ShortenUrlConstant.java
+++ b/src/main/java/org/chunsik/pq/shortenurl/util/constant/ShortenUrlConstant.java
@@ -3,6 +3,7 @@ package org.chunsik.pq.shortenurl.util.constant;
 public final class ShortenUrlConstant {
     public static final String BASE62_CHARACTER_SET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
     public static final String INIT_STRING_SET = "";
+    public static final String PREFIX_DOMAIN_URL = "https://www.qqqq.world/s/";
     public static final int INIT_NUMBER = 0;
     public static final int END_OF_GENERATE_NUMBER = 8;
     public static final int END_OF_DUPLICATION_TRY = 4;

--- a/src/main/java/org/chunsik/pq/shortenurl/util/constant/ShortenUrlConstant.java
+++ b/src/main/java/org/chunsik/pq/shortenurl/util/constant/ShortenUrlConstant.java
@@ -3,13 +3,11 @@ package org.chunsik.pq.shortenurl.util.constant;
 public final class ShortenUrlConstant {
     public static final String BASE62_CHARACTER_SET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
     public static final String INIT_STRING_SET = "";
-    public static final String PREFIX_DOMAIN_URL = "https://www.qqqq.world/s/";
     public static final int INIT_NUMBER = 0;
     public static final int END_OF_GENERATE_NUMBER = 8;
     public static final int END_OF_DUPLICATION_TRY = 4;
     public static final int END_OF_TRY_NUMBER = 5;
 
 
-    private ShortenUrlConstant() {
-    }
+    private ShortenUrlConstant() {}
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -55,3 +55,8 @@ cloud:
 openai:
   api:
     key: ${chunsik.openai.key}
+
+chunsik:
+  server:
+    domain: "api.qqqq.world"
+    url: "https://${chunsik.server.domain}"

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -57,3 +57,8 @@ cloud:
 openai:
   api:
     key: ${chunsik.openai.key}
+
+chunsik:
+  server:
+    domain: "localhost:8080"
+    url: "http://${chunsik.server.domain}"

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -55,3 +55,8 @@ cloud:
 openai:
   api:
     key: ${chunsik.openai.key}
+
+chunsik:
+  server:
+    domain: "api.qqqq.world"
+    url: "https://${chunsik.server.domain}"


### PR DESCRIPTION
# 단축 URL DB 저장 방식 수정

### 개요
> 단축 URL DB 저장 컬럼 수정

### 리뷰어가 꼭 봐줬으면 하는 부분
>  ShortenURL
- dest_url 컬럼의 속성 varchar(255) -> TEXT 변경
>ShortenUrlService
- destUrl DB 저장 방식 변경. 8자리 Key만 저장 -> 도메인 prefix 추가하여 저장.

### Jira ISSUE Keys
> 관련된 Jira 백로그 키를 나열해주세요. 여러개 있다면 여러개 작성해주세요
- PQ-96
