### PR TITLE
Fix: GenerateService의 findTicketById 메소드의 shortenUrl 변수에 prefix 응답 형식으로 수정

### DIFF
--- a/src/main/java/org/chunsik/pq/generate/service/GenerateService.java
+++ b/src/main/java/org/chunsik/pq/generate/service/GenerateService.java
@@ -43,6 +43,9 @@ public class GenerateService {
     @Value("${cloud.aws.s3.ticket}")
     private String ticketFolder;
 
+    @Value("${chunsik.server.url}")
+    private String serverDomain;
+
     @Transactional
     public GenerateResponseDTO generateImage(GenerateImageDTO generateImageDTO) {
         // 이미지 생성
@@ -111,7 +114,7 @@ public class GenerateService {
 
         String image_path = ticket.getImagePath();
         String title = ticket.getTitle();
-        String shortenUrl = ticket.getUrl().getDestURL();
+        String shortenUrl = serverDomain + "/s/" + ticket.getUrl().getDestURL();
 
         return new TicketResponseDTO(image_path, title, shortenUrl);
     }


### PR DESCRIPTION
fix: GenerateService의 findTicketById 메소드의 shortenUrl 변수에 prefix 응답 형식으로 수정

### 개요
> GenerateService의 findTicketById 메소드의 shortenUrl 변수에 prefix 응답 형식으로 수정

### 리뷰어가 꼭 봐줬으면 하는 부분
> 없습니다!