### PR TITLE
쿠키 도메인 오류로 인한 chunsik.domain 수정

### DIFF
--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -59,7 +59,7 @@ openai:
     key: ${chunsik.openai.key}
 
 chunsik:
-  domain: "localhost:8080"
+  domain: "localhost"
   front:
     domain: "localhost:8080"
     url: "http://${chunsik.front.domain}"


### PR DESCRIPTION
쿠키 도메인 오류로 인한 chunsik.domain 수정

### 개요
> Postman으로 쿠키 사용시 로컬 도메인 인식 문제로 localhost:8080 -> localhost 로 수정
### 리뷰어가 꼭 봐줬으면 하는 부분
> 없습니다
### Jira ISSUE Keys
> 해당되는 이슈 없음