### PR TITLE
Feat: 나의 4Q 태그 검색, 제목 검색 API 구현

### DIFF
--- a/src/main/java/org/chunsik/pq/mypage/controller/MyPageController.java
+++ b/src/main/java/org/chunsik/pq/mypage/controller/MyPageController.java
@@ -6,10 +6,7 @@ import org.chunsik.pq.mypage.dto.MyPQResponseDto;
 import org.chunsik.pq.mypage.service.MyPageService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -20,11 +17,27 @@ public class MyPageController {
 
     private final MyPageService myPageService;
 
+    // 내가 만든 PQ
     @GetMapping
     public ResponseEntity<List<MyPQResponseDto>> getMyPQ() {
         List<MyPQResponseDto> MyPQ = myPageService.getMyPQs();
         return ResponseEntity.ok(MyPQ);
     }
+
+    // 제목으로 필터링
+    @GetMapping("/title")
+    public ResponseEntity<List<MyPQResponseDto>> searchMyPQByTitle(@RequestParam String title) {
+        List<MyPQResponseDto> MyPQ = myPageService.getMyPQsByTitle(title);
+        return ResponseEntity.ok(MyPQ);
+    }
+
+    // 태그로 필터링
+    @GetMapping("/tag")
+    public ResponseEntity<List<MyPQResponseDto>> searchMyPQByTag(@RequestParam String tag) {
+        List<MyPQResponseDto> MyPQ = myPageService.getMyPQsByTag(tag);
+        return ResponseEntity.ok(MyPQ);
+    }
+
 
     // IllegalStateException을 처리하는 핸들러
     @ExceptionHandler(IllegalStateException.class)

--- a/src/main/java/org/chunsik/pq/mypage/dto/MyPQResponseDto.java
+++ b/src/main/java/org/chunsik/pq/mypage/dto/MyPQResponseDto.java
@@ -6,8 +6,10 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class MyPQResponseDto {
+    private Long ticketId;
     private String ticketUrl;
     private String title;
     private String formattedDate;
     private String categoryName;
+    private String backgroundImageUrl;
 }

--- a/src/main/java/org/chunsik/pq/mypage/service/MyPageService.java
+++ b/src/main/java/org/chunsik/pq/mypage/service/MyPageService.java
@@ -70,10 +70,12 @@ public class MyPageService {
 
                     // MyPQResponseDto 객체를 생성하여 반환
                     return new MyPQResponseDto(
+                            ticket.getId(),
                             ticket.getImagePath(),
                             ticket.getTitle(),
                             formattedDate,
-                            categoryName
+                            categoryName,
+                            ticket.getBackgroundImage().getUrl()
                     );
                 })
                 .collect(Collectors.toList());

--- a/src/main/java/org/chunsik/pq/mypage/service/MyPageService.java
+++ b/src/main/java/org/chunsik/pq/mypage/service/MyPageService.java
@@ -61,6 +61,7 @@ public class MyPageService {
         // 티켓 정보를 MyPQResponseDto 리스트로 변환하여 반환
         return tickets.stream()
                 .map(ticket -> {
+                    // CategoryName을 조회
                     String categoryName = categoryMap.get(ticket.getBackgroundImage().getCategoryId());
 
                     // 티켓의 생성일자를 YYYY/MM/DD 형식으로 포맷팅

--- a/src/main/java/org/chunsik/pq/mypage/service/MyPageService.java
+++ b/src/main/java/org/chunsik/pq/mypage/service/MyPageService.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
@@ -23,34 +24,42 @@ public class MyPageService {
     private final TicketRepository ticketRepository;
     private final UserManager userManager;
 
+    // 모든 티켓 정보를 가져오는 메서드
     public List<MyPQResponseDto> getMyPQs() {
-        // 현재 로그인한 사용자의 userId를 가져옴
+        return getMyPQsByFilter((userId, title) ->
+                ticketRepository.findTicketsByUserIdWithBackgroundImageOrderByCreatedAtDesc(userId), null);
+    }
+
+    // 제목으로 필터링된 티켓 정보를 가져오는 메서드
+    public List<MyPQResponseDto> getMyPQsByTitle(String title) {
+        return getMyPQsByFilter(ticketRepository::findTicketsByUserIdAndTitleContainingOrderByCreatedAtDesc, title);
+    }
+
+    // 태그로 필터링된 티켓 정보를 가져오는 메서드
+    public List<MyPQResponseDto> getMyPQsByTag(String tag) {
+        return getMyPQsByFilter(ticketRepository::findTicketsByUserIdAndTagNameOrderByCreatedAtDesc, tag);
+    }
+
+    // 공통 로직을 처리하는 메서드
+    private List<MyPQResponseDto> getMyPQsByFilter(BiFunction<Long, String, List<Ticket>> filterFunction, String title) {
         Long userId = userManager.currentUser()
                 .map(CustomUserDetails::getId)
                 .orElseThrow(() -> new IllegalStateException("User not authenticated"));
 
-        // 해당 사용자의 티켓 정보를 최신순 조회
-        List<Ticket> tickets = ticketRepository.findTicketsByUserIdWithBackgroundImageOrderByCreatedAtDesc(userId);
+        List<Ticket> tickets = filterFunction.apply(userId, title);
 
-        // 모든 카테고리 정보를 조회하여 categoryMap에 ID와 이름을 매핑
         List<Category> categories = categoryRepository.findAll();
         Map<Long, String> categoryMap = categories.stream()
                 .collect(Collectors.toMap(Category::getId, Category::getName));
 
-        // 날짜 형식을 지정
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy/MM/dd");
 
-        // 티켓 정보를 MyPQResponseDto 리스트로 변환하여 반환
         return tickets.stream()
                 .map(ticket -> {
-                    // CategoryName을 조회
                     String categoryName = categoryMap.get(ticket.getBackgroundImage().getCategoryId());
-
-                    // 티켓의 생성일자를 YYYY/MM/DD 형식으로 포맷팅
                     LocalDateTime createdAt = ticket.getCreatedAt();
                     String formattedDate = createdAt.format(formatter);
 
-                    // MyPQResponseDto 객체를 생성하여 반환
                     return new MyPQResponseDto(
                             ticket.getImagePath(),
                             ticket.getTitle(),

--- a/src/main/java/org/chunsik/pq/mypage/service/MyPageService.java
+++ b/src/main/java/org/chunsik/pq/mypage/service/MyPageService.java
@@ -42,24 +42,32 @@ public class MyPageService {
 
     // 공통 로직을 처리하는 메서드
     private List<MyPQResponseDto> getMyPQsByFilter(BiFunction<Long, String, List<Ticket>> filterFunction, String title) {
+        // 현재 로그인한 사용자의 userId를 가져옴
         Long userId = userManager.currentUser()
                 .map(CustomUserDetails::getId)
                 .orElseThrow(() -> new IllegalStateException("User not authenticated"));
 
+        // 해당 사용자의 티켓 정보를 최신순 조회
         List<Ticket> tickets = filterFunction.apply(userId, title);
 
+        // 모든 카테고리 정보를 조회하여 categoryMap에 ID와 이름을 매핑
         List<Category> categories = categoryRepository.findAll();
         Map<Long, String> categoryMap = categories.stream()
                 .collect(Collectors.toMap(Category::getId, Category::getName));
 
+        // 날짜 형식을 지정
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy/MM/dd");
 
+        // 티켓 정보를 MyPQResponseDto 리스트로 변환하여 반환
         return tickets.stream()
                 .map(ticket -> {
                     String categoryName = categoryMap.get(ticket.getBackgroundImage().getCategoryId());
+
+                    // 티켓의 생성일자를 YYYY/MM/DD 형식으로 포맷팅
                     LocalDateTime createdAt = ticket.getCreatedAt();
                     String formattedDate = createdAt.format(formatter);
 
+                    // MyPQResponseDto 객체를 생성하여 반환
                     return new MyPQResponseDto(
                             ticket.getImagePath(),
                             ticket.getTitle(),

--- a/src/main/java/org/chunsik/pq/s3/repository/TicketRepository.java
+++ b/src/main/java/org/chunsik/pq/s3/repository/TicketRepository.java
@@ -9,7 +9,22 @@ import java.util.List;
 
 public interface TicketRepository extends JpaRepository<Ticket, Long> {
 
-    @Query("SELECT t FROM Ticket t JOIN FETCH t.backgroundImage b WHERE t.userId = :userId ORDER BY t.createdAt DESC")
+    // userId로 티켓을 필터링하고 제목을 포함하는 티켓을 생성일자 내림차순으로 정렬하는 메서드
+    @Query("SELECT t FROM Ticket t WHERE t.userId = :userId AND t.title LIKE %:title% ORDER BY t.createdAt DESC")
+    List<Ticket> findTicketsByUserIdAndTitleContainingOrderByCreatedAtDesc(@Param("userId") Long userId, @Param("title") String title);
+
+    // userId로 티켓을 필터링하고 생성일자 내림차순으로 정렬하는 메서드
+    @Query("SELECT t FROM Ticket t WHERE t.userId = :userId ORDER BY t.createdAt DESC")
     List<Ticket> findTicketsByUserIdWithBackgroundImageOrderByCreatedAtDesc(@Param("userId") Long userId);
 
+    // 태그로 필터링된 티켓을 조회하는 메서드
+    @Query("SELECT t FROM Ticket t " +
+            "JOIN TagBackgroundImage tbi ON t.backgroundImage.id = tbi.photoBackgroundId " +
+            "JOIN Tag tag ON tbi.tagId = tag.id " +
+            "WHERE t.userId = :userId AND tag.name = :tag " +
+            "ORDER BY t.createdAt DESC")
+    List<Ticket> findTicketsByUserIdAndTagNameOrderByCreatedAtDesc(@Param("userId") Long userId, @Param("tag") String tag);
+
+
 }
+

--- a/src/main/java/org/chunsik/pq/s3/repository/TicketRepository.java
+++ b/src/main/java/org/chunsik/pq/s3/repository/TicketRepository.java
@@ -9,22 +9,20 @@ import java.util.List;
 
 public interface TicketRepository extends JpaRepository<Ticket, Long> {
 
-    // userId로 티켓을 필터링하고 생성일자 내림차순으로 정렬하는 메서드
+    // userId로 티켓을 필터링하고 생성일자 내림차순으로 정렬하면서 BackgroundImage를 fetch join
     @Query("SELECT t FROM Ticket t JOIN FETCH t.backgroundImage b WHERE t.userId = :userId ORDER BY t.createdAt DESC")
     List<Ticket> findTicketsByUserIdWithBackgroundImageOrderByCreatedAtDesc(@Param("userId") Long userId);
 
-    // userId로 티켓을 필터링하고 제목을 포함하는 티켓을 생성일자 내림차순으로 정렬하는 메서드
-    @Query("SELECT t FROM Ticket t WHERE t.userId = :userId AND t.title LIKE %:title% ORDER BY t.createdAt DESC")
+    // userId로 티켓을 필터링하고 제목을 포함하는 티켓을 생성일자 내림차순으로 정렬하면서 BackgroundImage를 fetch join
+    @Query("SELECT t FROM Ticket t JOIN FETCH t.backgroundImage b WHERE t.userId = :userId AND t.title LIKE %:title% ORDER BY t.createdAt DESC")
     List<Ticket> findTicketsByUserIdAndTitleContainingOrderByCreatedAtDesc(@Param("userId") Long userId, @Param("title") String title);
 
-    // 태그로 필터링된 티켓을 조회하는 메서드
+    // 태그로 필터링된 티켓을 조회하면서 BackgroundImage와 TagBackgroundImage를 fetch join
     @Query("SELECT t FROM Ticket t " +
-            "JOIN TagBackgroundImage tbi ON t.backgroundImage.id = tbi.photoBackgroundId " +
-            "JOIN Tag tag ON tbi.tagId = tag.id " +
+            "JOIN FETCH t.backgroundImage b " +
+            "JOIN FETCH TagBackgroundImage tbi ON b.id = tbi.photoBackgroundId " +
+            "JOIN FETCH Tag tag ON tbi.tagId = tag.id " +
             "WHERE t.userId = :userId AND tag.name = :tag " +
             "ORDER BY t.createdAt DESC")
     List<Ticket> findTicketsByUserIdAndTagNameOrderByCreatedAtDesc(@Param("userId") Long userId, @Param("tag") String tag);
-
-
 }
-

--- a/src/main/java/org/chunsik/pq/s3/repository/TicketRepository.java
+++ b/src/main/java/org/chunsik/pq/s3/repository/TicketRepository.java
@@ -9,13 +9,13 @@ import java.util.List;
 
 public interface TicketRepository extends JpaRepository<Ticket, Long> {
 
+    // userId로 티켓을 필터링하고 생성일자 내림차순으로 정렬하는 메서드
+    @Query("SELECT t FROM Ticket t JOIN FETCH t.backgroundImage b WHERE t.userId = :userId ORDER BY t.createdAt DESC")
+    List<Ticket> findTicketsByUserIdWithBackgroundImageOrderByCreatedAtDesc(@Param("userId") Long userId);
+
     // userId로 티켓을 필터링하고 제목을 포함하는 티켓을 생성일자 내림차순으로 정렬하는 메서드
     @Query("SELECT t FROM Ticket t WHERE t.userId = :userId AND t.title LIKE %:title% ORDER BY t.createdAt DESC")
     List<Ticket> findTicketsByUserIdAndTitleContainingOrderByCreatedAtDesc(@Param("userId") Long userId, @Param("title") String title);
-
-    // userId로 티켓을 필터링하고 생성일자 내림차순으로 정렬하는 메서드
-    @Query("SELECT t FROM Ticket t WHERE t.userId = :userId ORDER BY t.createdAt DESC")
-    List<Ticket> findTicketsByUserIdWithBackgroundImageOrderByCreatedAtDesc(@Param("userId") Long userId);
 
     // 태그로 필터링된 티켓을 조회하는 메서드
     @Query("SELECT t FROM Ticket t " +


### PR DESCRIPTION
# Feat: 나의 4Q 태그 검색, 제목 검색 API 구현

### 개요
> 변경된 부분을 짧게 요약해주세요.

- 나의 4Q 태그 검색, 제목 검색 API 구현
- 공통 로직 발생으로 중복된 코드 메서드로 처리
- 티켓Id와 배경이미지URL 응답 데이터에 추가

### 리뷰어가 꼭 봐줬으면 하는 부분
> 코드의 특정 부분을 지정해주셔도 좋고, 커밋을 지정해주셔도 좋고,   
> 로직적으로 제시해주셔도 좋습니다.
- 태그검색, 제목검색 쿼리
- getMyPQsByFilter 메서드
### Jira ISSUE Keys
> 관련된 Jira 백로그 키를 나열해주세요. 여러개 있다면 여러개 작성해주세요
- PQ-27 > PQ-53 > PQ-116