### PR TITLE
Fix: 회원가입 기능 수정

### DIFF
--- a/src/main/java/org/chunsik/pq/login/controller/ControllerExceptionHandler.java
+++ b/src/main/java/org/chunsik/pq/login/controller/ControllerExceptionHandler.java
@@ -19,7 +19,7 @@ public class ControllerExceptionHandler {
     //중복 이메일 가입 핸들러
     @ExceptionHandler(DuplicateEmailException.class)
     public ResponseEntity<?> handleDuplicateEmailException(DuplicateEmailException e) {
-        return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
+        return new ResponseEntity<>(e.getMessage(), HttpStatus.CONFLICT);
     }
 
     //로그인 실패 핸들러

--- a/src/main/java/org/chunsik/pq/login/dto/JoinDto.java
+++ b/src/main/java/org/chunsik/pq/login/dto/JoinDto.java
@@ -1,5 +1,6 @@
 package org.chunsik.pq.login.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
@@ -10,6 +11,7 @@ import lombok.Setter;
 public class JoinDto {
 
     @NotNull
+    @NotBlank
     private String nickname;
 
     @NotNull
@@ -17,6 +19,7 @@ public class JoinDto {
     private String email;
 
     @NotNull
+    @NotBlank
     private String password;
 
     // 기본 생성자

--- a/src/main/java/org/chunsik/pq/login/service/UserService.java
+++ b/src/main/java/org/chunsik/pq/login/service/UserService.java
@@ -21,7 +21,6 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.thymeleaf.spring6.processor.SpringUErrorsTagProcessor;
 
 import java.util.ArrayList;
 import java.util.Optional;
@@ -51,7 +50,7 @@ public class UserService {
     public User join(JoinDto joinDto, OauthProvider oauthProvider) {
 
         User user = User.create(
-                joinDto.getNickname(),
+                joinDto.getNickname().trim(),
                 joinDto.getEmail(),
                 passwordEncoder.encode(joinDto.getPassword()),
                 oauthProvider


### PR DESCRIPTION
Fix: 회원가입 기능 수정

### 개요
> 회원가입 DTO 필드에 @NotBlank 추가 (닉네임 쌩 공백 받지않도록)
회원 저장로직 수정 (회원 저장 시 양쪽 공백 제거, 중간 공백은 허용)
중복이메일 가입 시도 시 응답코드를 400 -> 409로 수정 (프론트 쪽에서 중복 이메일 오류인 것을 명시적으로 알 수 있도록)

### 리뷰어가 꼭 봐줬으면 하는 부분
> 409응답이 적절한지

### Jira ISSUE Keys
> 해당 이슈 없음
