### PR TITLE
fix: 로그아웃 수정

### DIFF
--- a/src/main/java/org/chunsik/pq/login/controller/UserController.java
+++ b/src/main/java/org/chunsik/pq/login/controller/UserController.java
@@ -3,10 +3,7 @@ package org.chunsik.pq.login.controller;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.chunsik.pq.login.dto.JoinDto;
-import org.chunsik.pq.login.dto.MeResponseDto;
-import org.chunsik.pq.login.dto.TokenDto;
-import org.chunsik.pq.login.dto.UserLoginRequestDto;
+import org.chunsik.pq.login.dto.*;
 import org.chunsik.pq.login.service.UserService;
 import org.chunsik.pq.model.OauthProvider;
 import org.springframework.beans.factory.annotation.Value;
@@ -49,6 +46,20 @@ public class UserController {
 
         return ResponseEntity.ok(responseBody);
     }
+
+    @PostMapping("/logout")
+    public ResponseEntity<LogoutSuccessDTO> logout(HttpServletResponse response) {
+        LogoutSuccessDTO logoutSuccessDTO = userService.logout();
+        Cookie refreshTokenCookie = new Cookie("refreshToken", null);
+        refreshTokenCookie.setHttpOnly(true);
+        refreshTokenCookie.setPath("/");
+        refreshTokenCookie.setMaxAge(0);
+        refreshTokenCookie.setDomain(cookieDomain);
+        response.addCookie(refreshTokenCookie);
+
+        return ResponseEntity.ok(logoutSuccessDTO);
+    }
+
 
     @PostMapping("/register")
     public ResponseEntity<?> join(@Validated @RequestBody JoinDto joinDto, Errors errors) {

--- a/src/main/java/org/chunsik/pq/login/dto/LogoutSuccessDTO.java
+++ b/src/main/java/org/chunsik/pq/login/dto/LogoutSuccessDTO.java
@@ -1,0 +1,10 @@
+package org.chunsik.pq.login.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class LogoutSuccessDTO {
+    private final String message;
+}

--- a/src/main/java/org/chunsik/pq/login/service/UserService.java
+++ b/src/main/java/org/chunsik/pq/login/service/UserService.java
@@ -2,10 +2,7 @@ package org.chunsik.pq.login.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.chunsik.pq.login.dto.JoinDto;
-import org.chunsik.pq.login.dto.MeResponseDto;
-import org.chunsik.pq.login.dto.SignUpOrLoginDto;
-import org.chunsik.pq.login.dto.TokenDto;
+import org.chunsik.pq.login.dto.*;
 import org.chunsik.pq.login.exception.DuplicateEmailException;
 import org.chunsik.pq.login.manager.UserManager;
 import org.chunsik.pq.login.repository.UserRepository;
@@ -97,5 +94,13 @@ public class UserService {
         String nickname = customUserDetails.getNickname();
         Long id = customUserDetails.getId();
         return new MeResponseDto(id, email, nickname);
+    }
+
+    public LogoutSuccessDTO logout(){
+        Optional<CustomUserDetails> currentUser = userManager.currentUser();
+        CustomUserDetails customUserDetails = currentUser.orElseThrow(() -> new AuthenticationException("No current user") {
+        });
+
+        return new LogoutSuccessDTO("logout success");
     }
 }


### PR DESCRIPTION


# 로그아웃 수정

### 개요
> 변경된 부분을 짧게 요약해주세요.
프론트에서 로그아웃시, RefreshToken 삭제되지 않아 로그아웃이 제대로 되지 않던 부분
-> logout 엔드포인트 구현해서 서버쪽 RefreshToken 삭제하도록 구현

### 리뷰어가 꼭 봐줬으면 하는 부분
> 코드의 특정 부분을 지정해주셔도 좋고, 커밋을 지정해주셔도 좋고,   
> 로직적으로 제시해주셔도 좋습니다.
- AccessToken을 헤더에 담아 /users/logout 접근시 RefreshToken 삭제
### Jira ISSUE Keys
> 관련된 Jira 백로그 키를 나열해주세요. 여러개 있다면 여러개 작성해주세요
- PQ-113
