### PR TITLE
Feat: 연관 이미지 추천 기능 구현

### DIFF
--- a/src/main/java/org/chunsik/pq/generate/controller/GenerateController.java
+++ b/src/main/java/org/chunsik/pq/generate/controller/GenerateController.java
@@ -9,6 +9,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
+import java.util.List;
 
 @RequiredArgsConstructor
 @RestController
@@ -18,6 +19,11 @@ public class GenerateController {
     @PostMapping("/image")
     public GenerateResponseDTO generateImage(@RequestBody GenerateImageDTO generateImageDTO) throws IOException {
         return generateService.generateImage(generateImageDTO);
+    }
+
+    @GetMapping("/image/relate/{id}")
+    public List<RelateImageDTO> getRelateImages(@PathVariable Long id) {
+        return generateService.getRelateImage(id);
     }
 
     @PostMapping("/ticket")

--- a/src/main/java/org/chunsik/pq/generate/dto/RelateImageDTO.java
+++ b/src/main/java/org/chunsik/pq/generate/dto/RelateImageDTO.java
@@ -1,0 +1,11 @@
+package org.chunsik.pq.generate.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class RelateImageDTO {
+    private final Long id;
+    private final String url;
+}

--- a/src/main/java/org/chunsik/pq/generate/repository/BackgroundImageRepository.java
+++ b/src/main/java/org/chunsik/pq/generate/repository/BackgroundImageRepository.java
@@ -1,7 +1,34 @@
 package org.chunsik.pq.generate.repository;
 
+import jakarta.persistence.Tuple;
 import org.chunsik.pq.generate.model.BackgroundImage;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface BackgroundImageRepository extends JpaRepository<BackgroundImage, Long> {
+    @Query(value = """
+            SELECT bi.id, bi.url
+            FROM (
+                SELECT bi.id, bi.url, COUNT(*) AS cnt
+                FROM background_image bi
+                JOIN tag_background_image tbi
+                ON bi.id = tbi.photo_background_id
+                GROUP BY bi.id
+            ) bi
+            JOIN (
+                SELECT *
+                FROM tag_background_image tbi
+                WHERE tbi.tag_id IN (:tagIds)
+            ) tbi
+            ON bi.id = tbi.photo_background_id
+            WHERE bi.id != :backgroundImgId
+            GROUP BY bi.id
+            ORDER BY COUNT(DISTINCT tbi.tag_id) DESC, bi.cnt ASC
+            """, nativeQuery = true)
+    Slice<Tuple> findRelateImgByTags(@Param("tagIds") List<Long> tagIds, Pageable pageable, Long backgroundImgId);
 }

--- a/src/main/java/org/chunsik/pq/generate/repository/TagBackgroundImageRepository.java
+++ b/src/main/java/org/chunsik/pq/generate/repository/TagBackgroundImageRepository.java
@@ -2,6 +2,11 @@ package org.chunsik.pq.generate.repository;
 
 import org.chunsik.pq.generate.model.TagBackgroundImage;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface TagBackgroundImageRepository extends JpaRepository<TagBackgroundImage, Long> {
+    @Query("SELECT tbi.tagId FROM TagBackgroundImage tbi WHERE tbi.photoBackgroundId = :photoBackgroundId")
+    List<Long> findTagIdsByPhotoBackgroundId(Long photoBackgroundId);
 }

--- a/src/main/java/org/chunsik/pq/generate/service/GenerateService.java
+++ b/src/main/java/org/chunsik/pq/generate/service/GenerateService.java
@@ -1,6 +1,7 @@
 package org.chunsik.pq.generate.service;
 
 import jakarta.annotation.Nullable;
+import jakarta.persistence.Tuple;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.chunsik.pq.generate.dto.*;
@@ -22,6 +23,8 @@ import org.chunsik.pq.s3.repository.TicketRepository;
 import org.chunsik.pq.shortenurl.model.ShortenURL;
 import org.chunsik.pq.shortenurl.repository.ShortenUrlRepository;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -95,6 +98,17 @@ public class GenerateService {
         return this.createImage(dto.getTicketImage(), dto.getShortenUrlId(),
                 dto.getTitle(), dto.getBackgroundImageId()
         );
+    }
+
+    public List<RelateImageDTO> getRelateImage(Long id) {
+        List<Long> tagIds = tagBackgroundImageRepository.findTagIdsByPhotoBackgroundId(id);
+        Slice<Tuple> slice = backgroundImageRepository.findRelateImgByTags(tagIds, PageRequest.of(0, 8), id); // 연관이미지가 8개 이상이면 8개까지만 추천.
+
+        return slice.getContent().stream()
+                .map(tuple -> new RelateImageDTO(
+                        tuple.get(0, Long.class),
+                        tuple.get(1, String.class)))
+                .toList();
     }
 
     @Transactional


### PR DESCRIPTION
# Feat: 연관 이미지 추천 기능 구현

### 개요
> 태그 기준으로 상세 이미지와 연관된 이미지를 추천

### 리뷰어가 꼭 봐줬으면 하는 부분
> findRelateImgByTags의 쿼리의 효율성이 적절한지 봐주시면 감사하겠습니다😀 
(쿼리에 대한 상세 설명 링크: https://shell-rise-8d0.notion.site/e130b9a3113b4703b6f68a43c13f12ee)