### PR TITLE
Feat: 태그 연관 배경이미지 추천 기능 구현

### DIFF
--- a/src/main/java/org/chunsik/pq/generate/controller/GenerateController.java
+++ b/src/main/java/org/chunsik/pq/generate/controller/GenerateController.java
@@ -9,6 +9,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
+import java.util.List;
 
 @RequiredArgsConstructor
 @RestController
@@ -18,6 +19,11 @@ public class GenerateController {
     @PostMapping("/image")
     public GenerateResponseDTO generateImage(@RequestBody GenerateImageDTO generateImageDTO) throws IOException {
         return generateService.generateImage(generateImageDTO);
+    }
+
+    @GetMapping("/image/relate/{id}")
+    public List<RelateImageDTO> getRelateImages(@PathVariable Long id) {
+        return generateService.getRelateImage(id);
     }
 
     @PostMapping("/ticket")

--- a/src/main/java/org/chunsik/pq/generate/dto/RelateImageDTO.java
+++ b/src/main/java/org/chunsik/pq/generate/dto/RelateImageDTO.java
@@ -1,0 +1,11 @@
+package org.chunsik.pq.generate.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class RelateImageDTO {
+    private final Long id;
+    private final String url;
+}

--- a/src/main/java/org/chunsik/pq/generate/repository/BackgroundImageRepositoryCustom.java
+++ b/src/main/java/org/chunsik/pq/generate/repository/BackgroundImageRepositoryCustom.java
@@ -2,9 +2,15 @@ package org.chunsik.pq.generate.repository;
 
 import org.chunsik.pq.gallery.dto.BackgroundImageDTO;
 import org.chunsik.pq.gallery.model.GallerySort;
+import org.chunsik.pq.generate.dto.RelateImageDTO;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface BackgroundImageRepositoryCustom {
     Page<BackgroundImageDTO> findByTagAndCategory(String tagName, String categoryName, GallerySort sort, Pageable pageable);
+
+    List<RelateImageDTO> findRelateImgByTags(@Param("tagIds") List<Long> tagIds, Long backgroundImgId);
 }

--- a/src/main/java/org/chunsik/pq/generate/repository/BackgroundImageRepositoryImpl.java
+++ b/src/main/java/org/chunsik/pq/generate/repository/BackgroundImageRepositoryImpl.java
@@ -206,14 +206,14 @@ public class BackgroundImageRepositoryImpl implements BackgroundImageRepositoryC
         QTagBackgroundImage tbi = new QTagBackgroundImage("tbi");
         QTagBackgroundImage whole = new QTagBackgroundImage("whole");
 
-        return queryFactory.
-                select(Projections.constructor(RelateImageDTO.class, bi.id, bi.url)).
-                from(bi).
-                join(tbi).on(bi.id.eq(tbi.photoBackgroundId).and(tbi.tagId.in(tagIds))).
-                join(whole).on(whole.photoBackgroundId.eq(bi.id)).
-                where(bi.id.ne(backgroundImgId)).
-                groupBy(bi.id).
-                orderBy(tbi.tagId.countDistinct().desc(), whole.tagId.countDistinct().asc())
+        return queryFactory
+                .select(Projections.constructor(RelateImageDTO.class, bi.id, bi.url))
+                .from(bi)
+                .join(tbi).on(bi.id.eq(tbi.photoBackgroundId).and(tbi.tagId.in(tagIds)))
+                .join(whole).on(whole.photoBackgroundId.eq(bi.id))
+                .where(bi.id.ne(backgroundImgId))
+                .groupBy(bi.id)
+                .orderBy(tbi.tagId.countDistinct().desc(), whole.tagId.countDistinct().asc())
                 .limit(8)
                 .fetch();
     }

--- a/src/main/java/org/chunsik/pq/generate/repository/BackgroundImageRepositoryImpl.java
+++ b/src/main/java/org/chunsik/pq/generate/repository/BackgroundImageRepositoryImpl.java
@@ -1,17 +1,22 @@
 package org.chunsik.pq.generate.repository;
 
 import com.querydsl.core.Tuple;
+import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.StringExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.chunsik.pq.gallery.dto.BackgroundImageDTO;
 import org.chunsik.pq.gallery.model.GallerySort;
+import org.chunsik.pq.generate.dto.RelateImageDTO;
+import org.chunsik.pq.generate.model.QBackgroundImage;
+import org.chunsik.pq.generate.model.QTagBackgroundImage;
 import org.chunsik.pq.login.manager.UserManager;
 import org.chunsik.pq.login.security.CustomUserDetails;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -195,4 +200,21 @@ public class BackgroundImageRepositoryImpl implements BackgroundImageRepositoryC
         }).collect(Collectors.toList());
     }
 
+    @Override
+    public List<RelateImageDTO> findRelateImgByTags(@Param("tagIds") List<Long> tagIds, Long backgroundImgId) {
+        QBackgroundImage bi = new QBackgroundImage("bi");
+        QTagBackgroundImage tbi = new QTagBackgroundImage("tbi");
+        QTagBackgroundImage whole = new QTagBackgroundImage("whole");
+
+        return queryFactory.
+                select(Projections.constructor(RelateImageDTO.class, bi.id, bi.url)).
+                from(bi).
+                join(tbi).on(bi.id.eq(tbi.photoBackgroundId).and(tbi.tagId.in(tagIds))).
+                join(whole).on(whole.photoBackgroundId.eq(bi.id)).
+                where(bi.id.ne(backgroundImgId)).
+                groupBy(bi.id).
+                orderBy(tbi.tagId.countDistinct().desc(), whole.tagId.countDistinct().asc())
+                .limit(8)
+                .fetch();
+    }
 }

--- a/src/main/java/org/chunsik/pq/generate/repository/TagBackgroundImageRepository.java
+++ b/src/main/java/org/chunsik/pq/generate/repository/TagBackgroundImageRepository.java
@@ -2,8 +2,11 @@ package org.chunsik.pq.generate.repository;
 
 import org.chunsik.pq.generate.model.TagBackgroundImage;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
 public interface TagBackgroundImageRepository extends JpaRepository<TagBackgroundImage, Long> {
+    @Query("SELECT tbi.tagId FROM TagBackgroundImage tbi WHERE tbi.photoBackgroundId = :photoBackgroundId")
+    List<Long> findTagIdsByPhotoBackgroundId(Long photoBackgroundId);
 }

--- a/src/main/java/org/chunsik/pq/generate/service/GenerateService.java
+++ b/src/main/java/org/chunsik/pq/generate/service/GenerateService.java
@@ -124,6 +124,11 @@ public class GenerateService {
         return new CreateImageResponseDto("Success", id);
     }
 
+    public List<RelateImageDTO> getRelateImage(Long id) {
+        List<Long> tagIds = tagBackgroundImageRepository.findTagIdsByPhotoBackgroundId(id);
+        return backgroundImageRepository.findRelateImgByTags(tagIds, id); // 연관이미지가 8개 이상이면 8개까지만 추천.
+    }
+
     public TicketResponseDTO findTicketById(Long ticketId) {
         Ticket ticket = ticketRepository.findById(ticketId).orElseThrow(() -> new NoSuchElementException("No ticket found for ticketId: " + ticketId));
 


### PR DESCRIPTION
# Feat: 태그 연관 배경이미지 추천 기능 구현

### 개요
> 배경 상세보기에 연관 이미지 추천 기능 구현
연관 이미지 쿼리에  QueryDSL 사용

### 리뷰어가 꼭 봐줬으면 하는 부분
> 없습니다!


### Jira ISSUE Keys
> 관련된 Jira 백로그 키를 나열해주세요. 여러개 있다면 여러개 작성해주세요
- PQ-74