### PR TITLE
Feat: 티켓 삭제 기능 구현

### DIFF
--- a/src/main/java/org/chunsik/pq/delete/controller/DeleteController.java
+++ b/src/main/java/org/chunsik/pq/delete/controller/DeleteController.java
@@ -1,0 +1,41 @@
+package org.chunsik.pq.delete.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.chunsik.pq.delete.service.DeleteService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+import java.util.NoSuchElementException;
+
+@RestController
+@RequiredArgsConstructor
+public class DeleteController {
+    private final DeleteService deleteService;
+
+    @DeleteMapping("/ticket/{id}")
+    public ResponseEntity<String> deleteTicket(@PathVariable Long id) {
+        deleteService.deleteById(id);
+        return new ResponseEntity<>("Delete successful", HttpStatus.NO_CONTENT);
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<String> handleAccessDeniedException(AccessDeniedException e) {
+        return new ResponseEntity<>(e.getMessage(), HttpStatus.UNAUTHORIZED);
+    }
+
+    @ExceptionHandler(NoSuchElementException.class)
+    public ResponseEntity<String> handleNoSuchElementException(NoSuchElementException e) {
+        return new ResponseEntity<>(e.getMessage(), HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(S3Exception.class)
+    public ResponseEntity<String> handleS3Exception(S3Exception e) {
+        return new ResponseEntity<>("An error occurred while processing your request with the S3 service.", HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/main/java/org/chunsik/pq/delete/service/DeleteService.java
+++ b/src/main/java/org/chunsik/pq/delete/service/DeleteService.java
@@ -1,0 +1,42 @@
+package org.chunsik.pq.delete.service;
+
+import jakarta.annotation.Nullable;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.chunsik.pq.login.manager.UserManager;
+import org.chunsik.pq.login.security.CustomUserDetails;
+import org.chunsik.pq.s3.manager.S3Manager;
+import org.chunsik.pq.s3.model.Ticket;
+import org.chunsik.pq.s3.repository.TicketRepository;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Service;
+
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class DeleteService {
+    private final S3Manager s3Manager;
+    private final UserManager userManager;
+    private final TicketRepository ticketRepository;
+
+    @Transactional
+    public void deleteById(Long id) {
+        Long userId = findLoginUserIdOrNull();
+        Ticket ticket = ticketRepository.findById(id).orElseThrow(() -> new NoSuchElementException("Ticket not found by Id: " + id));
+        if (ticket.getUserId() == null) {
+            throw new AccessDeniedException("Ticket is public property and cannot be deleted."); // 비회원이 만든 티켓은 삭제 허용하지 않음
+        } else if (!ticket.getUserId().equals(userId)) {
+            throw new AccessDeniedException("Authentication is necessary to delete a ticket."); // 요청 클라이언트 Id와 티켓 작성자 Id가 다르면 삭제 허용하지 않음
+        }
+        ticketRepository.deleteById(id); // 아래 코드에서 S3Exception이 발생하면 롤백
+        s3Manager.deleteFile(ticket.getImagePath());
+    }
+
+    @Nullable
+    private Long findLoginUserIdOrNull() {
+        Optional<CustomUserDetails> currentUser = userManager.currentUser();
+        return currentUser.map(CustomUserDetails::getId).orElse(null);
+    }
+}

--- a/src/main/java/org/chunsik/pq/s3/manager/S3Manager.java
+++ b/src/main/java/org/chunsik/pq/s3/manager/S3Manager.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
@@ -40,6 +41,16 @@ public class S3Manager {
         s3Client.putObject(putObjectRequest, RequestBody.fromFile(file));
 
         return new S3UploadResponseDTO(fullFileName, s3Url);
+    }
+
+    public void deleteFile(String fileDir) {
+        String baseUrl = "https://chunsik-dev.s3.ap-northeast-2.amazonaws.com/";
+        String fileName = fileDir.replace(baseUrl, ""); // ticket 디렉토리가 아닌 다른 디렉토리의 이미지를 삭제할 땐 파싱방식을 그거에 맞게 바꿔야 함. (fileName = 디렉토리/이미지명 형식)
+        DeleteObjectRequest request = DeleteObjectRequest.builder()
+                .bucket(bucketName)
+                .key(fileName)
+                .build();
+        s3Client.deleteObject(request);
     }
 
     private String generateFileName(String prefix) {

--- a/src/main/java/org/chunsik/pq/s3/model/Ticket.java
+++ b/src/main/java/org/chunsik/pq/s3/model/Ticket.java
@@ -21,7 +21,7 @@ public class Ticket {
     @Column(name = "user_id")
     private Long userId;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     @JoinColumn(name = "url_id", nullable = false)
     private ShortenURL url;
 
@@ -37,7 +37,7 @@ public class Ticket {
 
     @Column(name = "created_at", columnDefinition = "TIMESTAMP")
     private LocalDateTime createdAt;
-  
+
     public Ticket(Long userId, ShortenURL url, BackgroundImage backgroundImage, String title, String imagePath) {
         this.userId = userId;
         this.url = url;


### PR DESCRIPTION
# Feat: 티켓 삭제 기능 구현

### 개요
>  티켓 삭제 기능 구현
Delete 패키지에 삭제 기능 구현
티켓 삭제 시 S3 티켓 이미지와 단축 Url도 같이 삭제
티켓 엔티티의 Shorten_Url 엔티티는 CascadeType.REMOVE로 설정하여 티켓 삭제 시 같이 삭제되도록 구현

### 리뷰어가 꼭 봐줬으면 하는 부분
> 티켓 엔티티의 Shorten_url 엔티티를 CascadeType.REMOVE로 설정에 대해 괜찮은지
> generate에 기능이 너무 많아지는 것 같아서 delete 폴더를 따로 만들어서 티켓 삭제 부분은 여기서 구현했습니다.
>
### Jira ISSUE Keys
> 관련된 Jira 백로그 키를 나열해주세요. 여러개 있다면 여러개 작성해주세요
- PQ-138