### PR TITLE
Refactor: deleteTicket의 ResponseEntity 바디 메시지 삭제

### DIFF
--- a/src/main/java/org/chunsik/pq/delete/controller/DeleteController.java
+++ b/src/main/java/org/chunsik/pq/delete/controller/DeleteController.java
@@ -21,7 +21,7 @@ public class DeleteController {
     @DeleteMapping("/ticket/{id}")
     public ResponseEntity<String> deleteTicket(@PathVariable Long id) {
         deleteService.deleteById(id);
-        return new ResponseEntity<>("Delete successful", HttpStatus.NO_CONTENT);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 
     @ExceptionHandler(AccessDeniedException.class)


### PR DESCRIPTION
# Refactor: deleteTicket의 ResponseEntity 바디 메시지 삭제

### 개요
> 204(NO CONTENT) 응답은 메시지 바디를 무시하므로 의미없는 응답 메시지를 제거

### 리뷰어가 꼭 봐줬으면 하는 부분
> 없습니다!
### Jira ISSUE Keys
> 관련된 Jira 백로그 키를 나열해주세요. 여러개 있다면 여러개 작성해주세요
- 