### PR TITLE
Feat: 배경 이미지 조회수 기능 추가

### DIFF
--- a/src/main/java/org/chunsik/pq/gallery/service/GalleryService.java
+++ b/src/main/java/org/chunsik/pq/gallery/service/GalleryService.java
@@ -4,11 +4,14 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.chunsik.pq.gallery.model.UserLike;
 import org.chunsik.pq.gallery.repository.UserLikeRepository;
+import org.chunsik.pq.generate.model.BackgroundImage;
+import org.chunsik.pq.generate.repository.BackgroundImageRepository;
 import org.chunsik.pq.login.manager.UserManager;
 import org.chunsik.pq.login.security.CustomUserDetails;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.util.NoSuchElementException;
 
 @RequiredArgsConstructor
 @Service
@@ -16,6 +19,7 @@ public class GalleryService {
 
     private final UserLikeRepository likeRepository;
     private final UserManager userManager;
+    private final BackgroundImageRepository backgroundImageRepository;
 
     @Transactional
     public void addLike(Long imageId) {
@@ -36,4 +40,10 @@ public class GalleryService {
         likeRepository.deleteByUserIdAndPhotoBackgroundId(userId, imageId);
     }
 
+    @Transactional
+    public void addViewCount(Long imageId) {
+        BackgroundImage backgroundImage = backgroundImageRepository.findById(imageId).orElseThrow(() -> new NoSuchElementException("backgroundImage not found By Id:" + imageId));
+        backgroundImage.addViewCount();
+        backgroundImageRepository.save(backgroundImage);
+    }
 }

--- a/src/main/java/org/chunsik/pq/gallery/util/TimeUtils.java
+++ b/src/main/java/org/chunsik/pq/gallery/util/TimeUtils.java
@@ -1,0 +1,14 @@
+package org.chunsik.pq.gallery.util;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+
+public class TimeUtils {
+    public static int timeUntilMidnight() {
+        LocalDateTime now = LocalDateTime.now();
+
+        LocalDateTime midnight = now.toLocalDate().atStartOfDay().plusDays(1);
+
+        return (int) ChronoUnit.SECONDS.between(now, midnight);
+    }
+}

--- a/src/main/java/org/chunsik/pq/generate/model/BackgroundImage.java
+++ b/src/main/java/org/chunsik/pq/generate/model/BackgroundImage.java
@@ -33,6 +33,9 @@ public class BackgroundImage {
     @Column(name = "created_at", columnDefinition = "TIMESTAMP")
     private LocalDateTime createdAt;
 
+    @Column(name = "view_count", nullable = false)
+    private Long viewCount;
+
     @Builder
     public BackgroundImage(Long userId, String url, Long size, Long categoryId) {
         this.userId = userId;
@@ -40,5 +43,10 @@ public class BackgroundImage {
         this.size = size;
         this.categoryId = categoryId;
         this.createdAt = LocalDateTime.now();  // 객체 생성 시 자동으로 현재 시간 설정
+        this.viewCount = 0L;
+    }
+
+    public void addViewCount() {
+        this.viewCount += 1;
     }
 }


### PR DESCRIPTION
# Feat: 배경 이미지 조회수 기능 추가

### 개요
> 배경 이미지 엔티티에 조회수 필드 및 조회수 증가 메소드 추가<br>
GalleryController에 배경 이미지 조회수 증가 API 구현 
(조회수는 하루에 한번만 카운트하며 정각에 최신화 됨. 요청 쿠키에 방문했던
배경이미지 Id들을 담고 있으며 이 쿠키로 중복 방문을 판단.)<br>
GalleryService에 배경 이미지 조회수 증가 비즈니스 로직 구현<br>
쿠키의 유효기간을 설정하기 위해 (00:00 - 현재 시각)을 계산해주는 TimeUtils 구현<br>

### 리뷰어가 꼭 봐줬으면 하는 부분
> 쿠키 유효기간 설정 시 서버 시스템 기준의 현재 시간과 자정 시간의 차이를 계산하는데 AWS에 올리면 미국시간이 적용될 것 같네요?
쿠키는 비즈니스 로직과 별개여서 코드가 좀 복잡해도 컨트롤러 단에서 처리했습니다.
배경 이미지를 많이 조회할수록 쿠키 Value가 커지는데 보수적으로 계산했을 때 1000개 이상의 id를 담을 수 있습니다. (이용자가 1000개 이상의 배경을 볼 것 같진 않아서 쿠키로 구현했습니다.)

### Jira ISSUE Keys
> 관련된 Jira 백로그 키를 나열해주세요. 여러개 있다면 여러개 작성해주세요
- PQ-136