### PR TITLE
Fix: 포토티켓 생성하기에서 동일 shortenUrlId요청 에러발생 해결

### DIFF
--- a/src/main/java/org/chunsik/pq/generate/service/GenerateService.java
+++ b/src/main/java/org/chunsik/pq/generate/service/GenerateService.java
@@ -118,11 +118,35 @@ public class GenerateService {
         // 배경 이미지
         BackgroundImage backgroundImage = backgroundImageRepository.findById(backgroundImageId).orElseThrow(() -> new NoSuchElementException("No backgroundImage found for backgroundImageId: " + backgroundImageId));
 
-        Ticket ticket = new Ticket(userId, shortenURL, backgroundImage, title, s3UploadResponseDTO.getS3Url());
+        Optional<Ticket> existingTicket = ticketRepository.findByBackgroundImageIdAndUrlId(
+                backgroundImageId, shortenUrlId);
+
+        Ticket ticket;
+        if (existingTicket.isPresent()) {
+            // 티켓이 존재하면 기존 이미지를 삭제하고 업데이트
+            ticket = existingTicket.get();
+
+            // 기존 이미지 삭제
+            String oldImagePath = ticket.getImagePath();
+            if (oldImagePath != null && !oldImagePath.isEmpty()) {
+                s3Manager.deleteFile(oldImagePath);  // 기존 이미지를 S3에서 삭제
+            }
+
+            // 새로운 이미지 경로로 업데이트
+            ticket.updateTicket(s3UploadResponseDTO.getS3Url());
+        } else {
+            // 티켓이 존재하지 않으면 새로 생성
+            ticket = new Ticket(userId, shortenURL, backgroundImage, title, s3UploadResponseDTO.getS3Url());
+        }
+
+        // 티켓 저장
+        ticketRepository.save(ticket);
+
         Long id = ticketRepository.save(ticket).getId();
 
         return new CreateImageResponseDto("Success", id);
     }
+
 
     public List<RelateImageDTO> getRelateImage(Long id) {
         List<Long> tagIds = tagBackgroundImageRepository.findTagIdsByPhotoBackgroundId(id);

--- a/src/main/java/org/chunsik/pq/s3/model/Ticket.java
+++ b/src/main/java/org/chunsik/pq/s3/model/Ticket.java
@@ -18,7 +18,7 @@ public class Ticket {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "user_id")
+    @Column(name = "user_id", nullable = false)
     private Long userId;
 
     @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
@@ -29,10 +29,10 @@ public class Ticket {
     @JoinColumn(name = "background_id", nullable = false)
     private BackgroundImage backgroundImage;
 
-    @Column(name = "title")
+    @Column(name = "title", nullable = false)
     private String title;
 
-    @Column(name = "image_path")
+    @Column(name = "image_path", nullable = false)
     private String imagePath;
 
     @Column(name = "created_at", columnDefinition = "TIMESTAMP")
@@ -46,5 +46,9 @@ public class Ticket {
         this.imagePath = imagePath;
         this.createdAt = LocalDateTime.now();
     }
-}
 
+    public void updateTicket(String imagePath) {
+        this.imagePath = imagePath;
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/org/chunsik/pq/s3/model/Ticket.java
+++ b/src/main/java/org/chunsik/pq/s3/model/Ticket.java
@@ -18,7 +18,7 @@ public class Ticket {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "user_id", nullable = false)
+    @Column(name = "user_id")
     private Long userId;
 
     @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
@@ -29,10 +29,10 @@ public class Ticket {
     @JoinColumn(name = "background_id", nullable = false)
     private BackgroundImage backgroundImage;
 
-    @Column(name = "title", nullable = false)
+    @Column(name = "title")
     private String title;
 
-    @Column(name = "image_path", nullable = false)
+    @Column(name = "image_path")
     private String imagePath;
 
     @Column(name = "created_at", columnDefinition = "TIMESTAMP")

--- a/src/main/java/org/chunsik/pq/s3/repository/TicketRepository.java
+++ b/src/main/java/org/chunsik/pq/s3/repository/TicketRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface TicketRepository extends JpaRepository<Ticket, Long> {
 
@@ -17,6 +18,9 @@ public interface TicketRepository extends JpaRepository<Ticket, Long> {
             "GROUP BY t.id, b.id " +
             "ORDER BY t.createdAt DESC")
     List<Object[]> findTicketsWithLikesByUserIdOrderByCreatedAtDesc(@Param("userId") Long userId);
+
+    Optional<Ticket> findByBackgroundImageIdAndUrlId(Long backgroundImageId, Long shortenUrlId);
+
 }
 
 


### PR DESCRIPTION
# Fix: 포토티켓 생성하기에서 동일 shortenUrlId요청 에러발생 해결

### 개요
> 이미지ID와 단축URLID로 티켓테이블 탐색해서 존재하면 업데이트, 존재하지않으면 생성하는 로직으로 변경 

### 리뷰어가 꼭 봐줬으면 하는 부분
> 수정한 부분

### Jira ISSUE Keys
> PQ-117
